### PR TITLE
Fix wrong resolution selection

### DIFF
--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.cc
@@ -148,12 +148,11 @@ const std::vector<std::tuple<int, int>>& GetNonCrashingIngameResolutions() {
 
   std::call_once(
       *init_once_flag,
-      [=] () {
+      [&] () {
         d2::VideoMode current_video_mode = d2::d2gfx::GetVideoMode();
         const std::vector<std::tuple<int, int>>& selected_ingame_resolutions =
             SelectLocalOrOnlineResolutions();
 
-        selected_game_type = d2::d2client::GetGameType();
         non_crashing_ingame_resolutions.clear();
 
         if (current_video_mode == d2::VideoMode::kDirect3D
@@ -182,10 +181,18 @@ std::size_t GetMinConfigResolutionId() {
       : 1;
 }
 
+std::size_t GetMaxConfigResolutionId() {
+  return GetNumIngameResolutions() + GetMinConfigResolutionId();
+}
+
 std::size_t GetMinIngameResolutionId() {
   return GetNonCrashingIngameResolutions().at(0) == resolution_640x480
       ? 0
       : 2;
+}
+
+std::size_t GetMaxIngameResolutionId() {
+  return GetNumIngameResolutions() + GetMinIngameResolutionId();
 }
 
 std::size_t GetNumIngameResolutions() {

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.hpp
@@ -52,7 +52,11 @@
 namespace sgd2fr {
 
 std::size_t GetMinConfigResolutionId();
+std::size_t GetMaxConfigResolutionId();
+
 std::size_t GetMinIngameResolutionId();
+std::size_t GetMaxIngameResolutionId();
+
 std::size_t GetNumIngameResolutions();
 std::tuple<int, int> GetIngameResolutionFromId(std::size_t id);
 bool IsStandardResolution(const std::tuple<int, int>& width_and_height);

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry.cc
@@ -60,7 +60,7 @@ void __cdecl Sgd2fr_D2Client_GetResolutionRegistry(
   *reg_resolution_mode = config::GetIngameResolutionMode();
 
   if (*reg_resolution_mode < GetMinConfigResolutionId()
-      || *reg_resolution_mode >= GetNumIngameResolutions()) {
+      || *reg_resolution_mode >= GetMaxConfigResolutionId()) {
     *reg_resolution_mode = GetMinConfigResolutionId();
   }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu.cc
@@ -80,8 +80,7 @@ void __cdecl Sgd2fr_D2Client_SetResolutionFromOptionsMenu(
     return;
   }
 
-  std::size_t max_registry_resolution_id = GetNumIngameResolutions()
-      + GetMinConfigResolutionId();
+  std::size_t max_registry_resolution_id = GetMaxConfigResolutionId();
 
   if (reg_resolution_mode >= max_registry_resolution_id) {
     *reg_resolution_mode_out = GetMinConfigResolutionId();


### PR DESCRIPTION
The wrong resolution is selected if it is the last resolution in the config and 640x480 is not included in the list.