### PR TITLE
Port to 1.13c

### DIFF
--- a/SlashGaming-Diablo-II-Free-Resolution/resource/resource.rc
+++ b/SlashGaming-Diablo-II-Free-Resolution/resource/resource.rc
@@ -71,7 +71,7 @@ VS_VERSION_INFO    VERSIONINFO
   {
     BLOCK "040904E4" // Lang=US English, CharSet=Windows Multilingual
     {
-      VALUE "Build",            "2021-03-13\0"
+      VALUE "Build",            "2021-03-21\0"
       VALUE "Comments",         "Licensed under Affero GPL v3+.\0"
       VALUE "CompanyName",      "SlashGaming\0"
       VALUE "Developer",        "Mir Drualga\0"

--- a/SlashGaming-Diablo-II-Free-Resolution/resource/resource.rc
+++ b/SlashGaming-Diablo-II-Free-Resolution/resource/resource.rc
@@ -55,8 +55,8 @@ SLASH_ICON ICON "slashgaming_game_loader.ico"
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 
 VS_VERSION_INFO    VERSIONINFO
-  FILEVERSION      3,0,0,1
-  PRODUCTVERSION   3,0,0,1
+  FILEVERSION      3,0,1,0
+  PRODUCTVERSION   3,0,1,0
   FILEFLAGSMASK    0x3fL // VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
   FILEFLAGS        0x1L  // VS_FF_DEBUG|VS_FF_PRIVATEBUILD|VS_FF_PRERELEASE
@@ -71,7 +71,7 @@ VS_VERSION_INFO    VERSIONINFO
   {
     BLOCK "040904E4" // Lang=US English, CharSet=Windows Multilingual
     {
-      VALUE "Build",            "2021-02-26\0"
+      VALUE "Build",            "2021-03-13\0"
       VALUE "Comments",         "Licensed under Affero GPL v3+.\0"
       VALUE "CompanyName",      "SlashGaming\0"
       VALUE "Developer",        "Mir Drualga\0"
@@ -81,7 +81,7 @@ VS_VERSION_INFO    VERSIONINFO
       VALUE "LegalTrademarks",  "All rights reserved.\0"
       VALUE "PrivateBuild",     "\0"
       VALUE "ProductName",      "Diablo II Free Resolution\0"
-      VALUE "ProductVersion",   "3.0.0.1\0"
+      VALUE "ProductVersion",   "3.0.1.0\0"
       VALUE "SpecialBuild",     "\0"
       VALUE "Support",          "reddit.com/r/SlashDiablo\0"
     } // BLOCK "040904E4"

--- a/SlashGaming-Diablo-II-Free-Resolution/src/config.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/config.cc
@@ -77,7 +77,7 @@ constexpr int kMajorVersionAValue = 3;
 constexpr std::string_view kMajorVersionBKey = "Major Version B";
 constexpr int kMajorVersionBValue = 0;
 constexpr std::string_view kMinorVersionAKey = "Minor Version A";
-constexpr int kMinorVersionAValue = 0;
+constexpr int kMinorVersionAValue = 1;
 constexpr std::string_view kMinorVersionBKey = "Minor Version B";
 constexpr int kMinorVersionBValue = 0;
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/config.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/config.cc
@@ -130,7 +130,7 @@ constexpr std::string_view kDefaultCustomLeftScreenBorderBottomRightImagePath =
 constexpr std::string_view kCustomRightScreenBorderRightImagePathKey =
     "Right Screen Border Right Image Path";
 constexpr std::string_view kDefaultCustomRightScreenBorderRightImagePath =
-    "data\\SGD2FreeResolution\\ui\\panel\\D2MRFancyBorderInterfaceRight";
+    "data\\SGD2FreeResolution\\ui\\panel\\NeoD2MRFancyBorderInterfaceRight";
 
 constexpr std::string_view kCustomRightScreenBorderTopImagePathKey =
     "Right Screen Border Top Image Path";

--- a/SlashGaming-Diablo-II-Free-Resolution/src/config.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/config.cc
@@ -94,6 +94,12 @@ constexpr std::string_view kDefaultMainMenuResolution = "800x600";
 constexpr std::string_view kIngameResolutionModeKey = "Ingame Resolution Mode";
 constexpr unsigned int kDefaultIngameResolutionMode = 0;
 
+// Custom MPQ
+constexpr ::std::string_view kCustomMpqPathKey =
+    "Custom MPQ File";
+constexpr ::std::string_view kDefaultCustomMpqPath =
+    "SGD2FreeRes.mpq";
+
 // Draw variables.
 constexpr std::string_view kScreenBackgroundImagePathKey =
     "Screen Background Image Path";
@@ -402,6 +408,16 @@ bool AddMissingConfigEntries(
         kMainEntryKey,
         kMainMenuResolutionKey
     );
+  }
+
+  if constexpr (kIsLoadCustomMpq) {
+    if (!config_reader.HasString(kMainEntryKey, kCustomMpqPathKey)) {
+      config_reader.SetDeepString(
+          kDefaultCustomMpqPath.data(),
+          kMainEntryKey,
+          kCustomMpqPathKey
+      );
+    }
   }
 
   if constexpr (kIsAssetsPathCustomizable) {
@@ -714,6 +730,23 @@ void SetIngameResolutionMode(unsigned int resolution_mode) {
       );
 
   WriteConfig();
+}
+
+::std::string_view GetCustomMpqPath() {
+  static std::string custom_mpq_path;
+
+  std::call_once(
+      GetOnceFlag(kMainEntryKey, kCustomMpqPathKey),
+      [=] () {
+        custom_mpq_path = GetConfigReader()
+            .GetString(
+                kMainEntryKey,
+                kCustomMpqPathKey
+            );
+      }
+  );
+
+  return custom_mpq_path;
 }
 
 std::string_view GetScreenBackgroundImagePath() {

--- a/SlashGaming-Diablo-II-Free-Resolution/src/config.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/config.hpp
@@ -61,6 +61,8 @@ std::tuple<int, int> GetMainMenuResolution();
 unsigned int GetIngameResolutionMode();
 void SetIngameResolutionMode(unsigned int resolution_mode);
 
+::std::string_view GetCustomMpqPath();
+
 std::string_view GetScreenBackgroundImagePath();
 
 std::string_view GetCustomLeftScreenBorderLeftImagePath();

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/800_interface_bar.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/800_interface_bar.cc
@@ -60,13 +60,14 @@ constexpr int source_display_height = 600;
 unsigned int Get800InterfaceBarEnabledValue() {
   unsigned int resolution_mode = d2::d2gfx::GetResolutionMode();
 
-  if (resolution_mode <= 2) {
-    return resolution_mode;
-  }
+  ::std::tuple resolution = GetIngameResolutionFromId(resolution_mode);
 
-  return config::Is800InterfaceBarEnabled()
-      ? 2
-      : 0;
+  if (::std::get<0>(resolution) < 800
+      || !config::Is800InterfaceBarEnabled()) {
+    return 0;
+  } else {
+    return 2;
+  }
 }
 
 d2::PositionalRectangle_Api GetNewStatsButtonPosition() {

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/custom_mpq.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/custom_mpq.cc
@@ -43,16 +43,46 @@
  *  work.
  */
 
-#ifndef SGD2FR_COMPILE_TIME_SWITCH_HPP_
-#define SGD2FR_COMPILE_TIME_SWITCH_HPP_
+#include "custom_mpq.hpp"
 
-/**
- * Strictly a place where compile-time switch can be easily changed to
- * alter software behavior.
- */
+#include <sgd2mapi.hpp>
+#include "../config.hpp"
 
-constexpr bool kIsAssetsPathCustomizable = true;
+namespace sgd2fr {
+namespace {
 
-constexpr bool kIsLoadCustomMpq = true;
+static bool IsCustomMpqLoaded = false;
 
-#endif // SGD2FR_COMPILE_TIME_SWITCH_HPP_
+static ::d2::MpqArchiveHandle_Api& GetCustomMpq() {
+  static ::d2::MpqArchiveHandle_Api mpq;
+
+  return mpq;
+}
+
+} // namespace
+
+void LoadMpqOnce() {
+  if (IsCustomMpqLoaded) {
+    return;
+  }
+
+  GetCustomMpq().Open(
+      config::GetCustomMpqPath(),
+      false,
+      5000
+  );
+
+  IsCustomMpqLoaded = true;
+}
+
+void UnloadMpqOnce() {
+  if (!IsCustomMpqLoaded) {
+    return;
+  }
+
+  GetCustomMpq().Close();
+
+  IsCustomMpqLoaded = false;
+}
+
+} // namespace sgd2fr

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/custom_mpq.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/custom_mpq.hpp
@@ -43,16 +43,15 @@
  *  work.
  */
 
-#ifndef SGD2FR_COMPILE_TIME_SWITCH_HPP_
-#define SGD2FR_COMPILE_TIME_SWITCH_HPP_
+#ifndef SGD2FR_HELPER_CUSTOM_MPQ_HPP_
+#define SGD2FR_HELPER_CUSTOM_MPQ_HPP_
 
-/**
- * Strictly a place where compile-time switch can be easily changed to
- * alter software behavior.
- */
+namespace sgd2fr {
 
-constexpr bool kIsAssetsPathCustomizable = true;
+void LoadMpqOnce();
 
-constexpr bool kIsLoadCustomMpq = true;
+void UnloadMpqOnce();
 
-#endif // SGD2FR_COMPILE_TIME_SWITCH_HPP_
+} // namespace sgd2fr
+
+#endif SGD2FR_HELPER_CUSTOM_MPQ_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/file_version.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/file_version.cc
@@ -83,9 +83,10 @@ struct FileVersionTableEntryCompareKey {
 
 static constexpr const std::array<
     FileVersionTableEntry,
-    3
+    4
 > kFileVersionSortedTable = {{
     { FileVersion(1, 4, 4, 21), Glide3xVersion::kSven1_4_4_21 },
+    { FileVersion(1, 4, 6, 1), Glide3xVersion::kSven1_4_6_1 },
     { FileVersion(1, 4, 8, 3), Glide3xVersion::kSven1_4_8_3 },
     { FileVersion(3, 10, 0, 658), Glide3xVersion::kNGlide3_10_0_658 },
 }};

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.cc
@@ -189,10 +189,12 @@ const std::vector<std::tuple<int, int>>& GetNonCrashingIngameResolutions() {
   static d2::ClientGameType selected_game_type =
       d2::d2client::GetGameType();
   static std::vector<std::tuple<int, int>> non_crashing_ingame_resolutions;
+  static ::std::string gateway_ipv4_address;
 
   std::lock_guard lock(check_mutex);
 
-  if (selected_game_type != d2::d2client::GetGameType()) {
+  if (selected_game_type != d2::d2client::GetGameType()
+      || gateway_ipv4_address != ::d2::bnclient::GetGatewayIpV4Address()) {
     init_once_flag = std::make_unique<std::once_flag>();
   }
 
@@ -217,6 +219,9 @@ const std::vector<std::tuple<int, int>>& GetNonCrashingIngameResolutions() {
         } else {
           non_crashing_ingame_resolutions = selected_ingame_resolutions;
         }
+
+        selected_game_type = d2::d2client::GetGameType();
+        gateway_ipv4_address = ::d2::bnclient::GetGatewayIpV4Address();
       }
   );
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.cc
@@ -94,13 +94,15 @@ constexpr std::tuple resolution_800x600 = std::make_tuple(800, 600);
 const std::vector<std::tuple<int, int>>& GetResolutionsFromIpV4(
     std::string_view ipv4_address
 ) {
+  // Warning: This needs to be sorted lexicographically!
   static const ::std::array<
       Ipv4ResolutionTableEntry,
       3
   > kSortedIpv4ResolutionTable = {{
-      // play.slashdiablo.net
+
+      // evnt.slashdiablo.net
       Ipv4ResolutionTableEntry(
-          "209.222.25.91",
+          "207.252.75.177",
           {
               resolution_640x480,
               resolution_800x600,
@@ -108,9 +110,9 @@ const std::vector<std::tuple<int, int>>& GetResolutionsFromIpV4(
           }
       ),
 
-      // evnt.slashdiablo.net
+      // play.slashdiablo.net
       Ipv4ResolutionTableEntry(
-          "207.252.75.177",
+          "209.222.25.91",
           {
               resolution_640x480,
               resolution_800x600,

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.cc
@@ -50,6 +50,8 @@
 #include <set>
 #include <unordered_map>
 
+#include <mdc/error/exit_on_error.hpp>
+#include <mdc/wchar_t/filew.h>
 #include <sgd2mapi.hpp>
 #include "../config.hpp"
 #include "ddraw_version.hpp"
@@ -217,6 +219,50 @@ std::tuple<int, int> GetIngameResolutionFromId(std::size_t id) {
 
 bool IsStandardResolution(const std::tuple<int, int>& width_and_height) {
   return GetStandardResolutions().contains(width_and_height);
+}
+
+::std::tuple<int, int> GetVideoModeDisplayResolution() {
+  ::d2::VideoMode running_video_mode = ::d2::d2gfx::GetVideoMode();
+
+  switch (running_video_mode) {
+    case ::d2::VideoMode::kGdi: {
+      return ::std::make_tuple(
+          ::d2::d2gdi::GetBitBlockWidth(),
+          ::d2::d2gdi::GetBitBlockHeight()
+      );
+    }
+
+    case ::d2::VideoMode::kDirectDraw: {
+      return ::std::make_tuple(
+          ::d2::d2ddraw::GetDisplayWidth(),
+          ::d2::d2ddraw::GetDisplayHeight()
+      );
+    }
+
+    case ::d2::VideoMode::kGlide: {
+      return ::std::make_tuple(
+          ::d2::d2glide::GetDisplayWidth(),
+          ::d2::d2glide::GetDisplayHeight()
+      );
+    }
+
+    case ::d2::VideoMode::kDirect3D: {
+      return ::std::make_tuple(
+          ::d2::d2direct3d::GetDisplayWidth(),
+          ::d2::d2direct3d::GetDisplayHeight()
+      );
+    }
+
+    default: {
+      ::mdc::error::ExitOnConstantMappingError(
+          __FILEW__,
+          __LINE__,
+          static_cast<int>(running_video_mode)
+      );
+
+      return ::std::make_tuple(0, 0);
+    }
+  }
 }
 
 } // namespace sgd2fr

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.cc
@@ -88,8 +88,8 @@ struct Ipv4ResolutionTableEntryCompareKey {
   }
 };
 
-constexpr std::tuple resolution_640x480 = std::make_tuple(640, 480);
-constexpr std::tuple resolution_800x600 = std::make_tuple(800, 600);
+static constexpr std::tuple resolution_640x480 = std::make_tuple(640, 480);
+static constexpr std::tuple resolution_800x600 = std::make_tuple(800, 600);
 
 const std::vector<std::tuple<int, int>>& GetResolutionsFromIpV4(
     std::string_view ipv4_address

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.hpp
@@ -61,6 +61,12 @@ std::size_t GetNumIngameResolutions();
 std::tuple<int, int> GetIngameResolutionFromId(std::size_t id);
 bool IsStandardResolution(const std::tuple<int, int>& width_and_height);
 
+/**
+ * Returns the display resolution using the global variables
+ * corresponding to the current video mode.
+ */
+::std::tuple<int, int> GetVideoModeDisplayResolution();
+
 } // namespace sgd2fr
 
 #endif // SGD2FR_HELPER_GAME_RESOLUTION_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/glide3x_version.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/glide3x_version.cc
@@ -57,6 +57,10 @@ namespace sgd2fr::glide3x_version {
       return "Sven 1.4.4.21";
     }
 
+    case Glide3xVersion::kSven1_4_6_1: {
+      return "Sven 1.4.6.1";
+    }
+
     case Glide3xVersion::kSven1_4_8_3: {
       return "Sven 1.4.8.3";
     }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/glide3x_version.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/glide3x_version.hpp
@@ -52,6 +52,7 @@ namespace sgd2fr {
 
 enum class Glide3xVersion {
   kSven1_4_4_21,
+  kSven1_4_6_1,
   kSven1_4_8_3,
   kNGlide3_10_0_658
 };

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/patch_address_and_size.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/patch_address_and_size.hpp
@@ -1,0 +1,63 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_HELPER_PATCH_ADDRESS_AND_SIZE_HPP_
+#define SGD2FR_HELPER_PATCH_ADDRESS_AND_SIZE_HPP_
+
+#include <cstddef>
+#include <utility>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr {
+
+using PatchAddressAndSize = ::std::pair<
+    ::mapi::GameAddress,
+    ::std::size_t
+>;
+
+} // namespace sgd2fr
+
+#endif // SGD2FR_HELPER_PATCH_ADDRESS_AND_SIZE_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background.cc
@@ -45,8 +45,6 @@
 
 #include "d2client_draw_interface_bar_background.hpp"
 
-#include <windows.h>
-
 #include <sgd2mapi.hpp>
 #include "../../../config.hpp"
 #include "../../../helper/cel_file_collection.hpp"

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background.cc
@@ -55,20 +55,27 @@
 namespace sgd2fr {
 namespace {
 
-void DrawLeftInterfaceBarBackground() {
-  std::tuple width_and_height = GetIngameResolutionFromId(d2::d2gfx::GetResolutionMode());
+static void DrawAntiCheatBlackRectangle() {
+  static constexpr int interface_bar_height = 47;
 
-  d2::CelFile_Api& interface_bar_background_center = GetCelFile(config::GetInterfaceBarBackgroundCenterImagePath());
-  d2::CelFile_Api& interface_bar_background_left = GetCelFile(config::GetInterfaceBarBackgroundLeftImagePath());
+  ::std::tuple width_and_height = GetIngameResolutionFromId(
+      d2::d2gfx::GetResolutionMode()
+  );
 
   // Draw a black rectangle to stop transparent DC6 cheaters.
   d2::d2gfx::DrawRectangle(
       0,
-      std::get<1>(width_and_height) - 47,
-      std::get<0>(width_and_height) / 2,
+      std::get<1>(width_and_height) - interface_bar_height,
+      std::get<0>(width_and_height),
       std::get<1>(width_and_height),
       0,
       d2::DrawEffect::kNone
+  );
+}
+
+static void DrawLeftInterfaceBarBackground() {
+  ::std::tuple width_and_height = GetIngameResolutionFromId(
+      d2::d2gfx::GetResolutionMode()
   );
 
   d2::DrawCelFileFrameOptions frame_options;
@@ -80,6 +87,9 @@ void DrawLeftInterfaceBarBackground() {
   int width_covered = 117 + 48;
 
   // Draw the left part of the interface bar background.
+  d2::CelFile_Api& interface_bar_background_left = GetCelFile(
+      config::GetInterfaceBarBackgroundLeftImagePath()
+  );
   std::vector<d2::Cel_View> left_cels;
   for (unsigned int i = 0; i < interface_bar_background_left.GetNumFrames(); i += 1) {
     left_cels.push_back(interface_bar_background_left.GetCel(0, i));
@@ -97,10 +107,16 @@ void DrawLeftInterfaceBarBackground() {
         frame_options
     );
 
-    width_covered += left_cels.at(frame).GetWidth();
+    width_covered += interface_bar_background_left
+        .GetCel(0, frame)
+        .GetWidth();
   }
 
   // Draw the center part of the interface bar background.
+  d2::CelFile_Api& interface_bar_background_center = GetCelFile(
+      config::GetInterfaceBarBackgroundCenterImagePath()
+  );
+
   std::vector<d2::Cel_View> center_cels;
   for (unsigned int i = 0; i < interface_bar_background_center.GetNumFrames(); i += 1) {
     center_cels.push_back(interface_bar_background_center.GetCel(0, i));
@@ -119,20 +135,9 @@ void DrawLeftInterfaceBarBackground() {
   }
 }
 
-void DrawRightInterfaceBarBackground() {
-  std::tuple width_and_height = GetIngameResolutionFromId(d2::d2gfx::GetResolutionMode());
-
-  d2::CelFile_Api& interface_bar_background_center = GetCelFile(config::GetInterfaceBarBackgroundCenterImagePath());
-  d2::CelFile_Api& interface_bar_background_right = GetCelFile(config::GetInterfaceBarBackgroundRightImagePath());
-
-  // Draw a black rectangle to stop transparent DC6 cheaters.
-  d2::d2gfx::DrawRectangle(
-      std::get<0>(width_and_height) / 2,
-      std::get<1>(width_and_height) - 47,
-      std::get<0>(width_and_height),
-      std::get<1>(width_and_height),
-      0,
-      d2::DrawEffect::kNone
+static void DrawRightInterfaceBarBackground() {
+  ::std::tuple width_and_height = GetIngameResolutionFromId(
+      d2::d2gfx::GetResolutionMode()
   );
 
   d2::DrawCelFileFrameOptions frame_options;
@@ -165,6 +170,10 @@ void DrawRightInterfaceBarBackground() {
   }
 
   // Draw the center part of the interface bar background.
+  d2::CelFile_Api& interface_bar_background_center = GetCelFile(
+      config::GetInterfaceBarBackgroundCenterImagePath()
+  );
+
   std::vector<d2::Cel_View> center_cels;
   for (unsigned int frame = 0; frame < interface_bar_background_center.GetNumFrames(); frame += 1) {
     center_cels.push_back(interface_bar_background_center.GetCel(0, frame));
@@ -186,6 +195,7 @@ void DrawRightInterfaceBarBackground() {
 } // namespace
 
 void __cdecl Sgd2fr_D2Client_DrawInterfaceBarBackground() {
+  DrawAntiCheatBlackRectangle();
   DrawLeftInterfaceBarBackground();
   DrawRightInterfaceBarBackground();
 }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background.cc
@@ -90,10 +90,6 @@ static void DrawLeftInterfaceBarBackground() {
   d2::CelFile_Api& interface_bar_background_left = GetCelFile(
       config::GetInterfaceBarBackgroundLeftImagePath()
   );
-  std::vector<d2::Cel_View> left_cels;
-  for (unsigned int i = 0; i < interface_bar_background_left.GetNumFrames(); i += 1) {
-    left_cels.push_back(interface_bar_background_left.GetCel(0, i));
-  }
 
   for (unsigned int frame = 0;
       frame < interface_bar_background_left.GetNumFrames()
@@ -118,20 +114,27 @@ static void DrawLeftInterfaceBarBackground() {
   );
 
   std::vector<d2::Cel_View> center_cels;
-  for (unsigned int i = 0; i < interface_bar_background_center.GetNumFrames(); i += 1) {
+  for (unsigned int i = 0;
+      i < interface_bar_background_center.GetNumFrames();
+      i += 1) {
     center_cels.push_back(interface_bar_background_center.GetCel(0, i));
   }
 
-  for (unsigned int frame = 0; width_covered < (std::get<0>(width_and_height) / 2); frame += 1) {
+  for (unsigned int frame = 0;
+      width_covered < (std::get<0>(width_and_height) / 2);
+      frame += 1) {
+    unsigned int frame_to_draw =
+        frame % interface_bar_background_center.GetNumFrames();
+
     interface_bar_background_center.DrawFrame(
         width_covered,
         std::get<1>(width_and_height),
         0,
-        frame % interface_bar_background_center.GetNumFrames(),
+        frame_to_draw,
         frame_options
     );
 
-    width_covered += center_cels.at(frame).GetWidth();
+    width_covered += center_cels.at(frame_to_draw).GetWidth();
   }
 }
 
@@ -149,10 +152,9 @@ static void DrawRightInterfaceBarBackground() {
   int width_covered = 117 + 48;
 
   // Draw the left part of the interface bar background.
-  std::vector<d2::Cel_View> right_cels;
-  for (unsigned int frame = 0; frame < interface_bar_background_right.GetNumFrames(); frame += 1) {
-    right_cels.push_back(interface_bar_background_right.GetCel(0, frame));
-  }
+  d2::CelFile_Api& interface_bar_background_right = GetCelFile(
+      config::GetInterfaceBarBackgroundRightImagePath()
+  );
 
   for (unsigned int frame = 0;
       frame < interface_bar_background_right.GetNumFrames()
@@ -166,7 +168,9 @@ static void DrawRightInterfaceBarBackground() {
         frame_options
     );
 
-    width_covered += right_cels.at(frame).GetWidth();
+    width_covered += interface_bar_background_right
+        .GetCel(0, frame)
+        .GetWidth();
   }
 
   // Draw the center part of the interface bar background.
@@ -175,20 +179,25 @@ static void DrawRightInterfaceBarBackground() {
   );
 
   std::vector<d2::Cel_View> center_cels;
-  for (unsigned int frame = 0; frame < interface_bar_background_center.GetNumFrames(); frame += 1) {
+  for (unsigned int frame = 0;
+      frame < interface_bar_background_center.GetNumFrames();
+      frame += 1) {
     center_cels.push_back(interface_bar_background_center.GetCel(0, frame));
   }
 
   for (unsigned int frame = 0; width_covered < (std::get<0>(width_and_height) / 2); frame += 1) {
+    unsigned int frame_to_draw =
+        frame % interface_bar_background_center.GetNumFrames();
+
     interface_bar_background_center.DrawFrame(
         std::get<0>(width_and_height) - width_covered,
         std::get<1>(width_and_height),
         0,
-        frame % interface_bar_background_center.GetNumFrames(),
+        frame_to_draw,
         frame_options
     );
 
-    width_covered += center_cels.at(frame).GetWidth();
+    width_covered += center_cels.at(frame_to_draw).GetWidth();
   }
 }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch.cc
@@ -45,8 +45,6 @@
 
 #include "d2client_draw_interface_bar_background_patch.hpp"
 
-#include <unordered_map>
-
 #include <sgd2mapi.hpp>
 #include "../../../asm_x86_macro.h"
 
@@ -73,7 +71,8 @@ DrawInterfaceBarBackgroundPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_09D:
+    case ::d2::GameVersion::k1_13C: {
       return DrawInterfaceBarBackgroundPatch_1_09D();
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch_1_09d.cc
@@ -45,8 +45,6 @@
 
 #include "d2client_draw_interface_bar_background_patch_1_09d.hpp"
 
-#include <unordered_map>
-
 #include <sgd2mapi.hpp>
 #include "../../../asm_x86_macro.h"
 #include "d2client_draw_interface_bar_background.hpp"
@@ -99,34 +97,44 @@ DrawInterfaceBarBackgroundPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
   // Draw the new interface bar background.
+  PatchAddressAndSize patch_address_and_size = GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          GetPatchAddress(),
+          patch_address_and_size.first,
           mapi::BranchType::kCall,
           &InterceptionFunc01,
-          0x590A1 - 0x5909C
+          patch_address_and_size.second
       )
   );
 
   return patches;
 }
 
-const mapi::GameAddress&
-DrawInterfaceBarBackgroundPatch_1_09D::GetPatchAddress() {
-  static const std::unordered_map<
-      d2::GameVersion,
-      mapi::GameAddress
-  > kPatchAddresses = {
-      {
-          d2::GameVersion::k1_09D,
-          mapi::GameAddress::FromOffset(
+DrawInterfaceBarBackgroundPatch_1_09D::PatchAddressAndSize
+DrawInterfaceBarBackgroundPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
               ::d2::DefaultLibrary::kD2Client,
               0x5909C
-          )
-      }
-  };
+          ),
+          0x590A1 - 0x5909C
+      );
+    }
 
-  return kPatchAddresses.at(::d2::game_version::GetRunning());
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+        ::mapi::GameAddress::FromOffset(
+            ::d2::DefaultLibrary::kD2Client,
+            0x27297
+        ),
+        0x2729C - 0x27297
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_DRAW_D2CLIENT_DRAW_INTERFACE_BAR_BACKGROUND_PATCH_D2CLIENT_DRAW_INTERFACE_BAR_BACKGROUND_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_DRAW_D2CLIENT_DRAW_INTERFACE_BAR_BACKGROUND_PATCH_D2CLIENT_DRAW_INTERFACE_BAR_BACKGROUND_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,10 +62,16 @@ class DrawInterfaceBarBackgroundPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
-  static const mapi::GameAddress& GetPatchAddress();
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
 };
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_screen_background_patch/d2client_draw_screen_background_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_screen_background_patch/d2client_draw_screen_background_patch.cc
@@ -68,7 +68,8 @@ DrawScreenBackgroundPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_09D:
+    case ::d2::GameVersion::k1_13C: {
       return DrawScreenBackgroundPatch_1_09D();
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_screen_background_patch/d2client_draw_screen_background_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_screen_background_patch/d2client_draw_screen_background_patch_1_09d.cc
@@ -45,8 +45,6 @@
 
 #include "d2client_draw_screen_background_patch_1_09d.hpp"
 
-#include <unordered_map>
-
 #include "../../../asm_x86_macro.h"
 #include "d2client_draw_screen_background.hpp"
 
@@ -55,12 +53,24 @@ namespace {
 
 extern "C" static std::intptr_t __cdecl
 Sgd2fr_D2Client_DrawScreenBackground_GetJumpAddress_1_09D() {
-  mapi::GameAddress address = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x35750
-  );
 
-  return address.raw_address();
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return mapi::GameAddress::FromOffset(
+          ::d2::DefaultLibrary::kD2Client,
+          0x35750
+      ).raw_address();
+    }
+
+    case ::d2::GameVersion::k1_13C: {
+      return mapi::GameAddress::FromOffset(
+          ::d2::DefaultLibrary::kD2Client,
+          0x5C5C0
+      ).raw_address();
+    }
+  }
 }
 
 static __declspec(naked) void __cdecl InterceptionFunc01() {
@@ -107,86 +117,116 @@ DrawScreenBackgroundPatch_1_09D::MakePatches() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   // Draw the new screen background.
+  PatchAddressAndSize patch_address_and_size_01 = GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          GetPatchAddress01(),
+          patch_address_and_size_01.first,
           mapi::BranchType::kCall,
           &InterceptionFunc01,
-          0x86970 - 0x8696B
+          patch_address_and_size_01.second
       )
   );
 
   // Disable the left screen background.
+  PatchAddressAndSize patch_address_and_size_02 = GetPatchAddressAndSize02();
   patches.push_back(
       mapi::GamePatch::MakeGameNopPatch(
-          GetPatchAddress02(),
-          0x58FB1 - 0x58F1B
+          patch_address_and_size_02.first,
+          patch_address_and_size_02.second
       )
   );
 
   // Disable the right screen background.
+  PatchAddressAndSize patch_address_and_size_03 = GetPatchAddressAndSize03();
   patches.push_back(
       mapi::GamePatch::MakeGameNopPatch(
-          GetPatchAddress03(),
-          0x5909C - 0x58FF0
+          patch_address_and_size_03.first,
+          patch_address_and_size_03.second
       )
   );
 
   return patches;
 }
 
-const mapi::GameAddress& 
-DrawScreenBackgroundPatch_1_09D::GetPatchAddress01() {
-  static const std::unordered_map<
-      d2::GameVersion,
-      mapi::GameAddress
-  > kPatchAddresses01 = {
-      {
-          d2::GameVersion::k1_09D,
-          mapi::GameAddress::FromOffset(
+DrawScreenBackgroundPatch_1_09D::PatchAddressAndSize
+DrawScreenBackgroundPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
               ::d2::DefaultLibrary::kD2Client,
               0x8696B
-          )
-      }
-  };
+          ),
+          0x86970 - 0x8696B
+      );
+    }
 
-  return kPatchAddresses01.at(::d2::game_version::GetRunning());
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+        ::mapi::GameAddress::FromOffset(
+            ::d2::DefaultLibrary::kD2Client,
+            0xC3AA6
+        ),
+        0xC3AAB - 0xC3AA6
+      );
+    }
+  }
 }
 
-const mapi::GameAddress&
-DrawScreenBackgroundPatch_1_09D::GetPatchAddress02() {
-  static const std::unordered_map<
-      d2::GameVersion,
-      mapi::GameAddress
-  > kPatchAddresses02 = {
-      {
-          d2::GameVersion::k1_09D,
-          mapi::GameAddress::FromOffset(
+DrawScreenBackgroundPatch_1_09D::PatchAddressAndSize
+DrawScreenBackgroundPatch_1_09D::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
               ::d2::DefaultLibrary::kD2Client,
               0x58F1B
-          )
-      }
-  };
+          ),
+          0x58FB1 - 0x58F1B
+      );
+    }
 
-  return kPatchAddresses02.at(::d2::game_version::GetRunning());
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+        ::mapi::GameAddress::FromOffset(
+            ::d2::DefaultLibrary::kD2Client,
+            0x271ED
+        ),
+        0x27287 - 0x271ED
+      );
+    }
+  }
 }
 
-const mapi::GameAddress&
-DrawScreenBackgroundPatch_1_09D::GetPatchAddress03() {
-  static const std::unordered_map<
-      d2::GameVersion,
-      mapi::GameAddress
-  > kPatchAddresses03 = {
-      {
-          d2::GameVersion::k1_09D,
-          mapi::GameAddress::FromOffset(
+DrawScreenBackgroundPatch_1_09D::PatchAddressAndSize
+DrawScreenBackgroundPatch_1_09D::GetPatchAddressAndSize03() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
               ::d2::DefaultLibrary::kD2Client,
               0x58FF0
-          )
-      }
-  };
+          ),
+          0x5909C - 0x58FF0
+      );
+    }
 
-  return kPatchAddresses03.at(::d2::game_version::GetRunning());
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+        ::mapi::GameAddress::FromOffset(
+            ::d2::DefaultLibrary::kD2Client,
+            0x270F1
+        ),
+        0x271AE - 0x270F1
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_screen_background_patch/d2client_draw_screen_background_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_screen_background_patch/d2client_draw_screen_background_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_DRAW_D2CLIENT_DRAW_SCREEN_BACKGROUND_PATCH_D2CLIENT_DRAW_SCREEN_BACKGROUND_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_DRAW_D2CLIENT_DRAW_SCREEN_BACKGROUND_PATCH_D2CLIENT_DRAW_SCREEN_BACKGROUND_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,12 +62,15 @@ class DrawScreenBackgroundPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<mapi::GameAddress, ::std::size_t>;
+
   std::vector<mapi::GamePatch> patches_;
 
-  static const mapi::GameAddress& GetPatchAddress01();
-  static const mapi::GameAddress& GetPatchAddress02();
-  static const mapi::GameAddress& GetPatchAddress03();
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
+  static PatchAddressAndSize GetPatchAddressAndSize03();
 };
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch.cc
@@ -45,8 +45,6 @@
 
 #include "d2client_enable_800_interface_bar_patch.hpp"
 
-#include "d2client_enable_800_interface_bar_patch_1_09d.hpp"
-
 namespace sgd2fr::patches::d2client {
 
 Enable800InterfaceBarPatch::Enable800InterfaceBarPatch()
@@ -72,6 +70,10 @@ Enable800InterfaceBarPatch::MakePatch() {
   switch (running_game_version) {
     case ::d2::GameVersion::k1_09D: {
       return Enable800InterfaceBarPatch_1_09D();
+    }
+
+    case ::d2::GameVersion::k1_13C: {
+      return Enable800InterfaceBarPatch_1_13C();
     }
   }
 }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch.hpp
@@ -50,13 +50,15 @@
 
 #include <sgd2mapi.hpp>
 #include "d2client_enable_800_interface_bar_patch_1_09d.hpp"
+#include "d2client_enable_800_interface_bar_patch_1_13c.hpp"
 
 namespace sgd2fr::patches::d2client {
 
 class Enable800InterfaceBarPatch {
  public:
   using PatchVariant = std::variant<
-      Enable800InterfaceBarPatch_1_09D
+      Enable800InterfaceBarPatch_1_09D,
+      Enable800InterfaceBarPatch_1_13C
   >;
 
   Enable800InterfaceBarPatch();

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch_1_09d.cc
@@ -45,15 +45,13 @@
 
 #include "d2client_enable_800_interface_bar_patch_1_09d.hpp"
 
-#include <unordered_map>
-
 #include "../../../asm_x86_macro.h"
 #include "d2client_enable_800_interface_bar.hpp"
 
 namespace sgd2fr::patches::d2client {
 namespace {
 
-__declspec(naked) void __cdecl InterceptionFunc_01() {
+__declspec(naked) void __cdecl InterceptionFunc01() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -69,7 +67,7 @@ __declspec(naked) void __cdecl InterceptionFunc_01() {
   ASM_X86(ret);
 }
 
-__declspec(naked) void __cdecl InterceptionFunc_02() {
+__declspec(naked) void __cdecl InterceptionFunc02() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -105,67 +103,69 @@ void Enable800InterfaceBarPatch_1_09D::Remove() {
   }
 }
 
-const mapi::GameAddress&
-Enable800InterfaceBarPatch_1_09D::GetPatchAddress01() {
-  static const std::unordered_map<
-      d2::GameVersion,
-      mapi::GameAddress
-  > kPatchAddresses = {
-      {
-          d2::GameVersion::k1_09D,
-          mapi::GameAddress::FromOffset(
-              ::d2::DefaultLibrary::kD2Client,
-              0x590A9
-          )
-      }
-  };
-
-  return kPatchAddresses.at(::d2::game_version::GetRunning());
-}
-
-const mapi::GameAddress&
-Enable800InterfaceBarPatch_1_09D::GetPatchAddress02() {
-  static const std::unordered_map<
-      d2::GameVersion,
-      mapi::GameAddress
-  > kPatchAddresses = {
-      {
-          d2::GameVersion::k1_09D,
-          mapi::GameAddress::FromOffset(
-              ::d2::DefaultLibrary::kD2Client,
-              0x59228
-          )
-      }
-  };
-
-  return kPatchAddresses.at(::d2::game_version::GetRunning());
-}
-
 std::vector<mapi::GamePatch>
 Enable800InterfaceBarPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
   // Enable drawing the 800x600 interface bar.
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          GetPatchAddress01(),
+          patch_address_and_size_01.first,
           mapi::BranchType::kCall,
-          &InterceptionFunc_01,
-          0x590AE - 0x590A9
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
       )
   );
 
   // Draw the 800x600 interface bar.
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          GetPatchAddress02(),
+          patch_address_and_size_02.first,
           mapi::BranchType::kCall,
-          &InterceptionFunc_02,
-          0x592A5 - 0x59228
+          &InterceptionFunc02,
+          patch_address_and_size_02.second
       )
   );
 
   return patches;
+}
+
+Enable800InterfaceBarPatch_1_09D::PatchAddressAndSize
+Enable800InterfaceBarPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x590A9
+          ),
+          0x590AE - 0x590A9
+      );
+    }
+  }
+}
+
+Enable800InterfaceBarPatch_1_09D::PatchAddressAndSize
+Enable800InterfaceBarPatch_1_09D::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x59228
+          ),
+          0x592A5 - 0x59228
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch_1_09d.hpp
@@ -60,11 +60,17 @@ class Enable800InterfaceBarPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
-  static const mapi::GameAddress& GetPatchAddress01();
-  static const mapi::GameAddress& GetPatchAddress02();
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
 };
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch_1_13c.cc
@@ -43,40 +43,100 @@
  *  work.
  */
 
-#ifndef SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_1_09D_HPP_
-#define SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_1_09D_HPP_
+#include "d2client_enable_800_interface_bar_patch_1_13c.hpp"
 
-#include <cstddef>
-#include <utility>
-#include <vector>
-
-#include <sgd2mapi.hpp>
+#include "../../../asm_x86_macro.h"
+#include "d2client_enable_800_interface_bar.hpp"
 
 namespace sgd2fr::patches::d2client {
+namespace {
 
-class Enable800NewStatsButtonPatch_1_09D {
- public:
-  Enable800NewStatsButtonPatch_1_09D();
+__declspec(naked) void __cdecl InterceptionFunc01() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
 
-  void Apply();
-  void Remove();
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
 
- private:
-  using PatchAddressAndSize = ::std::pair<
-      ::mapi::GameAddress,
-      ::std::size_t
-  >;
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2Client_Enable800InterfaceBar));
 
-  std::vector<mapi::GamePatch> patches_;
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
 
-  static std::vector<mapi::GamePatch> MakePatches();
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
 
-  static PatchAddressAndSize GetPatchAddressAndSize01();
-  static PatchAddressAndSize GetPatchAddressAndSize02();
-  static PatchAddressAndSize GetPatchAddressAndSize03();
-  static PatchAddressAndSize GetPatchAddressAndSize04();
-};
+__declspec(naked) void __cdecl InterceptionFunc02() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(push ecx);
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2Client_Draw800InterfaceBar));
+  ASM_X86(add esp, 4);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+} // namespace
+
+Enable800InterfaceBarPatch_1_13C::Enable800InterfaceBarPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void Enable800InterfaceBarPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void Enable800InterfaceBarPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Remove();
+  }
+}
+
+std::vector<mapi::GamePatch>
+Enable800InterfaceBarPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  // Enable drawing the 800x600 interface bar.
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  return patches;
+}
+
+Enable800InterfaceBarPatch_1_13C::PatchAddressAndSize
+Enable800InterfaceBarPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x272A2
+          ),
+          0x272A7 - 0x272A2
+      );
+    }
+  }
+}
 
 } // namespace sgd2fr::patches::d2client
-
-#endif // SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_1_09D_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch_1_13c.hpp
@@ -43,20 +43,18 @@
  *  work.
  */
 
-#ifndef SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_1_09D_HPP_
-#define SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_1_09D_HPP_
+#ifndef SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_INTERFACE_BAR_PATCH_D2CLIENT_ENABLE_800_INTERFACE_BAR_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_INTERFACE_BAR_PATCH_D2CLIENT_ENABLE_800_INTERFACE_BAR_PATCH_1_13C_HPP_
 
-#include <cstddef>
-#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
 
 namespace sgd2fr::patches::d2client {
 
-class Enable800NewStatsButtonPatch_1_09D {
+class Enable800InterfaceBarPatch_1_13C {
  public:
-  Enable800NewStatsButtonPatch_1_09D();
+  Enable800InterfaceBarPatch_1_13C();
 
   void Apply();
   void Remove();
@@ -72,11 +70,8 @@ class Enable800NewStatsButtonPatch_1_09D {
   static std::vector<mapi::GamePatch> MakePatches();
 
   static PatchAddressAndSize GetPatchAddressAndSize01();
-  static PatchAddressAndSize GetPatchAddressAndSize02();
-  static PatchAddressAndSize GetPatchAddressAndSize03();
-  static PatchAddressAndSize GetPatchAddressAndSize04();
 };
 
 } // namespace sgd2fr::patches::d2client
 
-#endif // SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_1_09D_HPP_
+#endif // SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_INTERFACE_BAR_PATCH_D2CLIENT_ENABLE_800_INTERFACE_BAR_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button.cc
@@ -54,6 +54,10 @@ std::uint32_t __cdecl Sgd2fr_D2Client_Enable800NewSkillButton() {
   return Get800InterfaceBarEnabledValue();
 }
 
+std::uint32_t __cdecl Sgd2fr_D2Client_Get800NewSkillButtonEnabledValue() {
+  return Get800InterfaceBarEnabledValue();
+}
+
 mapi::bool32 __cdecl Sgd2fr_D2Client_IsMouseOver800NewSkillButton() {
   return IsMouseOverNewSkillButton();
 }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button.hpp
@@ -53,7 +53,15 @@
 namespace sgd2fr::patches {
 
 extern "C" std::uint32_t __cdecl Sgd2fr_D2Client_Enable800NewSkillButton();
+
+/**
+ * Returns 0 if using 640x480 style, or 2 if 800x600 style.
+ */
+extern "C" std::uint32_t __cdecl
+Sgd2fr_D2Client_Get800NewSkillButtonEnabledValue();
+
 extern "C" mapi::bool32 __cdecl Sgd2fr_D2Client_IsMouseOver800NewSkillButton();
+
 extern "C" void __cdecl Sgd2fr_D2Client_Set800NewSkillPopupText();
 
 extern "C" mapi::bool32 __cdecl Sgd2fr_D2Client_Draw800NewSkillButton(

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch.cc
@@ -47,7 +47,9 @@
 
 namespace sgd2fr::patches::d2client {
 
-Enable800NewSkillButtonPatch::Enable800NewSkillButtonPatch() = default;
+Enable800NewSkillButtonPatch::Enable800NewSkillButtonPatch()
+    : patch_(MakePatch()) {
+}
 
 void Enable800NewSkillButtonPatch::Apply() {
   std::visit([](auto& patch) {
@@ -62,12 +64,17 @@ void Enable800NewSkillButtonPatch::Remove() {
 }
 
 Enable800NewSkillButtonPatch::PatchVariant
-Enable800NewSkillButtonPatch::MakePatches() {
+Enable800NewSkillButtonPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
+  MessageBoxA(nullptr, "HELLO1", "", MB_OK);
 
   switch (running_game_version) {
     case ::d2::GameVersion::k1_09D: {
       return Enable800NewSkillButtonPatch_1_09D();
+    }
+
+    case ::d2::GameVersion::k1_13C: {
+      return Enable800NewSkillButtonPatch_1_13C();
     }
   }
 }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch.cc
@@ -66,7 +66,6 @@ void Enable800NewSkillButtonPatch::Remove() {
 Enable800NewSkillButtonPatch::PatchVariant
 Enable800NewSkillButtonPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
-  MessageBoxA(nullptr, "HELLO1", "", MB_OK);
 
   switch (running_game_version) {
     case ::d2::GameVersion::k1_09D: {

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch.hpp
@@ -50,13 +50,15 @@
 
 #include <sgd2mapi.hpp>
 #include "d2client_enable_800_new_skill_button_patch_1_09d.hpp"
+#include "d2client_enable_800_new_skill_button_patch_1_13c.hpp"
 
 namespace sgd2fr::patches::d2client {
 
 class Enable800NewSkillButtonPatch {
  public:
   using PatchVariant = std::variant<
-      Enable800NewSkillButtonPatch_1_09D
+      Enable800NewSkillButtonPatch_1_09D,
+      Enable800NewSkillButtonPatch_1_13C
   >;
 
   Enable800NewSkillButtonPatch();
@@ -67,7 +69,7 @@ class Enable800NewSkillButtonPatch {
  private:
   PatchVariant patch_;
 
-  static PatchVariant MakePatches();
+  static PatchVariant MakePatch();
 };
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch_1_13c.cc
@@ -1,0 +1,356 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2client_enable_800_new_skill_button_patch_1_13c.hpp"
+
+#include "../../../asm_x86_macro.h"
+#include "d2client_enable_800_new_skill_button.hpp"
+
+extern "C" {
+
+void __cdecl
+D2Client_Enable800NewSkillButtonPatch_1_13C_InterceptionFunc01();
+
+void __cdecl
+D2Client_Enable800NewSkillButtonPatch_1_13C_InterceptionFunc02();
+
+} // extern "C"
+
+namespace sgd2fr::patches::d2client {
+
+Enable800NewSkillButtonPatch_1_13C::Enable800NewSkillButtonPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void Enable800NewSkillButtonPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void Enable800NewSkillButtonPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Remove();
+  }
+}
+
+std::vector<mapi::GamePatch>
+Enable800NewSkillButtonPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  // Enable drawing the New Skill button on the interface bar when the
+  // Skill Tree Screen is open or screens on both sides are open.
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewSkillButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  // Disable drawing the 640x480 "New Skill" text and New Skill button
+  // underlay on the left side.
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_02.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewSkillButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_02.second
+      )
+  );
+
+  // Enable drawing the New Skill button animation when button is
+  // pressed.
+  PatchAddressAndSize patch_address_and_size_03 =
+      GetPatchAddressAndSize03();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_03.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewSkillButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_03.second
+      )
+  );
+
+  // Enable drawing the New Skill button when there are skill points to
+  // spend.
+  PatchAddressAndSize patch_address_and_size_04 =
+      GetPatchAddressAndSize04();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_04.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewSkillButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_04.second
+      )
+  );
+
+  // Adjust the mouse position detection for New Skill button.
+  PatchAddressAndSize patch_address_and_size_05 =
+      GetPatchAddressAndSize05();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_05.first,
+          ::mapi::BranchType::kJump,
+          &D2Client_Enable800NewSkillButtonPatch_1_13C_InterceptionFunc02,
+          patch_address_and_size_05.second
+      )
+  );
+
+  // Enable additional New Skill button pressed check for mouse
+  // position detection for New Skill button press.
+  PatchAddressAndSize patch_address_and_size_06 =
+      GetPatchAddressAndSize06();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_06.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewSkillButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_06.second
+      )
+  );
+
+  // Enable use of 800x600 mouse positon detection code for New Skill
+  // button press.
+  PatchAddressAndSize patch_address_and_size_07 =
+      GetPatchAddressAndSize07();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_07.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewSkillButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_07.second
+      )
+  );
+
+  // Enable additional New Skill button pressed check for mouse
+  // position detection for New Skill button press and opening the
+  // Skill Tree Screen.
+  PatchAddressAndSize patch_address_and_size_08 =
+      GetPatchAddressAndSize08();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_08.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewSkillButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_08.second
+      )
+  );
+
+  // Enable use of 800x600 mouse positon detection code for New Skill
+  // button press and opening the Skill Tree Screen.
+  PatchAddressAndSize patch_address_and_size_09 =
+      GetPatchAddressAndSize09();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_09.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewSkillButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_09.second
+      )
+  );
+
+  return patches;
+}
+
+Enable800NewSkillButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewSkillButtonPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x50207
+          ),
+          0x5020C - 0x50207
+      );
+    }
+  }
+}
+
+Enable800NewSkillButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewSkillButtonPatch_1_13C::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x502A5
+          ),
+          0x502AA - 0x502A5
+      );
+    }
+  }
+}
+
+Enable800NewSkillButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewSkillButtonPatch_1_13C::GetPatchAddressAndSize03() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x5031C
+          ),
+          0x50321 - 0x5031C
+      );
+    }
+  }
+}
+
+Enable800NewSkillButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewSkillButtonPatch_1_13C::GetPatchAddressAndSize04() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x50380
+          ),
+          0x50385 - 0x50380
+      );
+    }
+  }
+}
+
+Enable800NewSkillButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewSkillButtonPatch_1_13C::GetPatchAddressAndSize05() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x4FE70
+          ),
+          0x4FEB4 - 0x4FE70
+      );
+    }
+  }
+}
+
+Enable800NewSkillButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewSkillButtonPatch_1_13C::GetPatchAddressAndSize06() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x506AF
+          ),
+          0x506B4 - 0x506AF
+      );
+    }
+  }
+}
+
+Enable800NewSkillButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewSkillButtonPatch_1_13C::GetPatchAddressAndSize07() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x506C9
+          ),
+          0x506CE - 0x506C9
+      );
+    }
+  }
+}
+
+Enable800NewSkillButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewSkillButtonPatch_1_13C::GetPatchAddressAndSize08() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x50810
+          ),
+          0x50815 - 0x50810
+      );
+    }
+  }
+}
+
+Enable800NewSkillButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewSkillButtonPatch_1_13C::GetPatchAddressAndSize09() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x5082E
+          ),
+          0x50833 - 0x5082E
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch_1_13c.cc
@@ -197,6 +197,19 @@ Enable800NewSkillButtonPatch_1_13C::MakePatches() {
       )
   );
 
+  // Enable drawing the New Skill button press when there are no skill
+  // points.
+  PatchAddressAndSize patch_address_and_size_10 =
+      GetPatchAddressAndSize10();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_10.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewSkillButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_10.second
+      )
+  );
+
   return patches;
 }
 
@@ -348,6 +361,23 @@ Enable800NewSkillButtonPatch_1_13C::GetPatchAddressAndSize09() {
               0x5082E
           ),
           0x50833 - 0x5082E
+      );
+    }
+  }
+}
+
+Enable800NewSkillButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewSkillButtonPatch_1_13C::GetPatchAddressAndSize10() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x50023
+          ),
+          0x50028 - 0x50023
       );
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch_1_13c.hpp
@@ -43,8 +43,8 @@
  *  work.
  */
 
-#ifndef SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_1_09D_HPP_
-#define SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_1_09D_HPP_
+#ifndef SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_SKILL_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_SKILL_BUTTON_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_SKILL_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_SKILL_BUTTON_PATCH_1_13C_HPP_
 
 #include <cstddef>
 #include <utility>
@@ -54,9 +54,9 @@
 
 namespace sgd2fr::patches::d2client {
 
-class Enable800NewStatsButtonPatch_1_09D {
+class Enable800NewSkillButtonPatch_1_13C {
  public:
-  Enable800NewStatsButtonPatch_1_09D();
+  Enable800NewSkillButtonPatch_1_13C();
 
   void Apply();
   void Remove();
@@ -75,8 +75,13 @@ class Enable800NewStatsButtonPatch_1_09D {
   static PatchAddressAndSize GetPatchAddressAndSize02();
   static PatchAddressAndSize GetPatchAddressAndSize03();
   static PatchAddressAndSize GetPatchAddressAndSize04();
+  static PatchAddressAndSize GetPatchAddressAndSize05();
+  static PatchAddressAndSize GetPatchAddressAndSize06();
+  static PatchAddressAndSize GetPatchAddressAndSize07();
+  static PatchAddressAndSize GetPatchAddressAndSize08();
+  static PatchAddressAndSize GetPatchAddressAndSize09();
 };
 
 } // namespace sgd2fr::patches::d2client
 
-#endif // SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_1_09D_HPP_
+#endif // SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_SKILL_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_SKILL_BUTTON_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch_1_13c.hpp
@@ -80,6 +80,7 @@ class Enable800NewSkillButtonPatch_1_13C {
   static PatchAddressAndSize GetPatchAddressAndSize07();
   static PatchAddressAndSize GetPatchAddressAndSize08();
   static PatchAddressAndSize GetPatchAddressAndSize09();
+  static PatchAddressAndSize GetPatchAddressAndSize10();
 };
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch_1_13c_shim.asm
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch_1_13c_shim.asm
@@ -1,0 +1,90 @@
+;
+; SlashGaming Diablo II Free Resolution
+; Copyright (C) 2019-2021  Mir Drualga
+;
+; This file is part of SlashGaming Diablo II Free Resolution.
+;
+;  This program is free software: you can redistribute it and/or modify
+;  it under the terms of the GNU Affero General Public License as published
+;  by the Free Software Foundation, either version 3 of the License, or
+;  (at your option) any later version.
+;
+;  This program is distributed in the hope that it will be useful,
+;  but WITHOUT ANY WARRANTY; without even the implied warranty of
+;  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;  GNU Affero General Public License for more details.
+;
+;  You should have received a copy of the GNU Affero General Public License
+;  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;
+;  Additional permissions under GNU Affero General Public License version 3
+;  section 7
+;
+;  If you modify this Program, or any covered work, by linking or combining
+;  it with Diablo II (or a modified version of that game and its
+;  libraries), containing parts covered by the terms of Blizzard End User
+;  License Agreement, the licensors of this Program grant you additional
+;  permission to convey the resulting work. This additional permission is
+;  also extended to any combination of expansions, mods, and remasters of
+;  the game.
+;
+;  If you modify this Program, or any covered work, by linking or combining
+;  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+;  Glide, OpenGL, or Rave wrapper (or modified versions of those
+;  libraries), containing parts not covered by a compatible license, the
+;  licensors of this Program grant you additional permission to convey the
+;  resulting work.
+;
+;  If you modify this Program, or any covered work, by linking or combining
+;  it with any library (or a modified version of that library) that links
+;  to Diablo II (or a modified version of that game and its libraries),
+;  containing parts not covered by a compatible license, the licensors of
+;  this Program grant you additional permission to convey the resulting
+;  work.
+;
+
+global _D2Client_Enable800NewSkillButtonPatch_1_13C_InterceptionFunc01
+global _D2Client_Enable800NewSkillButtonPatch_1_13C_InterceptionFunc02
+
+extern _Sgd2fr_D2Client_Get800NewSkillButtonEnabledValue
+extern _Sgd2fr_D2Client_IsMouseOver800NewSkillButton
+
+section .data
+
+section .bss
+
+section .text
+
+;
+; External
+;
+
+_D2Client_Enable800NewSkillButtonPatch_1_13C_InterceptionFunc01:
+    push ebp
+    mov ebp, esp
+
+    push ecx
+    push edx
+
+    call _Sgd2fr_D2Client_Get800NewSkillButtonEnabledValue
+
+    pop edx
+    pop ecx
+
+    leave
+    ret
+
+_D2Client_Enable800NewSkillButtonPatch_1_13C_InterceptionFunc02:
+    push ebp
+    mov ebp, esp
+
+    push ecx
+    push edx
+
+    call _Sgd2fr_D2Client_IsMouseOver800NewSkillButton
+
+    pop edx
+    pop ecx
+
+    leave
+    ret

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button.cc
@@ -54,6 +54,10 @@ std::uint32_t __cdecl Sgd2fr_D2Client_Enable800NewStatsButton() {
   return Get800InterfaceBarEnabledValue();
 }
 
+std::uint32_t __cdecl Sgd2fr_D2Client_Get800NewStatsButtonEnabledValue() {
+  return Get800InterfaceBarEnabledValue();
+}
+
 mapi::bool32 __cdecl Sgd2fr_D2Client_IsMouseOver800NewStatsButton() {
   return IsMouseOverNewStatsButton();
 }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button.hpp
@@ -54,6 +54,12 @@ namespace sgd2fr::patches {
 
 extern "C" std::uint32_t __cdecl Sgd2fr_D2Client_Enable800NewStatsButton();
 
+/**
+ * Returns 0 if using 640x480 style, or 2 if 800x600 style.
+ */
+extern "C" std::uint32_t __cdecl
+Sgd2fr_D2Client_Get800NewStatsButtonEnabledValue();
+
 extern "C" mapi::bool32 __cdecl
 Sgd2fr_D2Client_IsMouseOver800NewStatsButton();
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch.cc
@@ -71,6 +71,10 @@ Enable800NewStatsButtonPatch::MakePatch() {
     case d2::GameVersion::k1_09D: {
       return Enable800NewStatsButtonPatch_1_09D();
     }
+
+    case d2::GameVersion::k1_13C: {
+      return Enable800NewStatsButtonPatch_1_13C();
+    }
   }
 }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch.hpp
@@ -50,13 +50,15 @@
 
 #include <sgd2mapi.hpp>
 #include "d2client_enable_800_new_stats_button_patch_1_09d.hpp"
+#include "d2client_enable_800_new_stats_button_patch_1_13c.hpp"
 
 namespace sgd2fr::patches::d2client {
 
 class Enable800NewStatsButtonPatch {
  public:
   using PatchVariant = std::variant<
-      Enable800NewStatsButtonPatch_1_09D
+      Enable800NewStatsButtonPatch_1_09D,
+      Enable800NewStatsButtonPatch_1_13C
   >;
 
   Enable800NewStatsButtonPatch();

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_09d.cc
@@ -51,7 +51,7 @@
 namespace sgd2fr::patches::d2client {
 namespace {
 
-__declspec(naked) void __cdecl InterceptionFunc_01() {
+__declspec(naked) void __cdecl InterceptionFunc01() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -67,7 +67,7 @@ __declspec(naked) void __cdecl InterceptionFunc_01() {
   ASM_X86(ret);
 }
 
-__declspec(naked) void __cdecl InterceptionFunc_02() {
+__declspec(naked) void __cdecl InterceptionFunc02() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -87,7 +87,7 @@ __declspec(naked) void __cdecl InterceptionFunc_02() {
   ASM_X86(ret);
 }
 
-__declspec(naked) void __cdecl InterceptionFunc_03() {
+__declspec(naked) void __cdecl InterceptionFunc03() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -105,7 +105,7 @@ __declspec(naked) void __cdecl InterceptionFunc_03() {
   ASM_X86(ret);
 }
 
-__declspec(naked) void __cdecl InterceptionFunc_04() {
+__declspec(naked) void __cdecl InterceptionFunc04() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -125,7 +125,7 @@ __declspec(naked) void __cdecl InterceptionFunc_04() {
   ASM_X86(ret);
 }
 
-__declspec(naked) void __cdecl InterceptionFunc_05() {
+__declspec(naked) void __cdecl InterceptionFunc05() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -168,62 +168,50 @@ Enable800NewStatsButtonPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
   // Enable the click on 800x600 New Stats button sound.
-  mapi::GameAddress game_address_01 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x48264
-  );
-
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          std::move(game_address_01),
+          patch_address_and_size_01.first,
           mapi::BranchType::kCall,
-          &InterceptionFunc_01,
-          0x48269 - 0x48264
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
       )
   );
 
-  mapi::GameAddress game_address_02 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x48283
-  );
-
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          std::move(game_address_02),
+          patch_address_and_size_02.first,
           mapi::BranchType::kCall,
-          &InterceptionFunc_01,
-          0x48288 - 0x48283
+          &InterceptionFunc01,
+          patch_address_and_size_02.second
       )
   );
 
   // Adjust the click detection of the New Stats button sound.
-  mapi::GameAddress game_address_03 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x4831C
-  );
-
+  PatchAddressAndSize patch_address_and_size_03 =
+      GetPatchAddressAndSize03();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          std::move(game_address_03),
+          patch_address_and_size_03.first,
           mapi::BranchType::kCall,
-          &InterceptionFunc_02,
-          0x4834C - 0x4831C
+          &InterceptionFunc02,
+          patch_address_and_size_03.second
       )
   );
 
   // Enable displaying of the (Lying) Character Screen when the 800x600 New
   // Stats button is clicked.
-  mapi::GameAddress game_address_04 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x48524
-  );
-
+  PatchAddressAndSize patch_address_and_size_04 =
+      GetPatchAddressAndSize04();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          std::move(game_address_04),
+          patch_address_and_size_04.first,
           mapi::BranchType::kCall,
-          &InterceptionFunc_01,
-          0x48529 - 0x48524
+          &InterceptionFunc01,
+          patch_address_and_size_04.second
       )
   );
 
@@ -236,7 +224,7 @@ Enable800NewStatsButtonPatch_1_09D::MakePatches() {
       mapi::GamePatch::MakeGameBranchPatch(
           std::move(game_address_05),
           mapi::BranchType::kCall,
-          &InterceptionFunc_01,
+          &InterceptionFunc01,
           0x48547 - 0x48542
       )
   );
@@ -252,7 +240,7 @@ Enable800NewStatsButtonPatch_1_09D::MakePatches() {
       mapi::GamePatch::MakeGameBranchPatch(
           std::move(game_address_06),
           mapi::BranchType::kCall,
-          &InterceptionFunc_02,
+          &InterceptionFunc02,
           0x48640 - 0x48608
       )
   );
@@ -267,7 +255,7 @@ Enable800NewStatsButtonPatch_1_09D::MakePatches() {
       mapi::GamePatch::MakeGameBranchPatch(
           std::move(game_address_07),
           mapi::BranchType::kCall,
-          &InterceptionFunc_01,
+          &InterceptionFunc01,
           0x48A1E - 0x48A19
       )
   );
@@ -282,7 +270,7 @@ Enable800NewStatsButtonPatch_1_09D::MakePatches() {
       mapi::GamePatch::MakeGameBranchPatch(
           std::move(game_address_08),
           mapi::BranchType::kCall,
-          &InterceptionFunc_02,
+          &InterceptionFunc02,
           0x48B40 - 0x48B08
       )
   );
@@ -297,7 +285,7 @@ Enable800NewStatsButtonPatch_1_09D::MakePatches() {
       mapi::GamePatch::MakeGameBranchPatch(
           std::move(game_address_09),
           mapi::BranchType::kCall,
-          &InterceptionFunc_01,
+          &InterceptionFunc01,
           0x488D2 - 0x488CD
       )
   );
@@ -311,7 +299,7 @@ Enable800NewStatsButtonPatch_1_09D::MakePatches() {
       mapi::GamePatch::MakeGameBranchPatch(
           std::move(game_address_10),
           mapi::BranchType::kCall,
-          &InterceptionFunc_01,
+          &InterceptionFunc01,
           0x489A6 - 0x489A1
       )
   );
@@ -326,7 +314,7 @@ Enable800NewStatsButtonPatch_1_09D::MakePatches() {
       mapi::GamePatch::MakeGameBranchPatch(
           std::move(game_address_11),
           mapi::BranchType::kCall,
-          &InterceptionFunc_01,
+          &InterceptionFunc01,
           0x48AA8 - 0x48AA3
       )
   );
@@ -341,7 +329,7 @@ Enable800NewStatsButtonPatch_1_09D::MakePatches() {
       mapi::GamePatch::MakeGameBranchPatch(
           std::move(game_address_12),
           mapi::BranchType::kCall,
-          &InterceptionFunc_02,
+          &InterceptionFunc02,
           0x48B81 - 0x48B5C
       )
   );
@@ -356,7 +344,7 @@ Enable800NewStatsButtonPatch_1_09D::MakePatches() {
       mapi::GamePatch::MakeGameBranchPatch(
           std::move(game_address_13),
           mapi::BranchType::kCall,
-          &InterceptionFunc_03,
+          &InterceptionFunc03,
           0x48BB1 - 0x48B93
       )
   );
@@ -371,7 +359,7 @@ Enable800NewStatsButtonPatch_1_09D::MakePatches() {
       mapi::GamePatch::MakeGameBranchPatch(
           std::move(game_address_14),
           mapi::BranchType::kCall,
-          &InterceptionFunc_04,
+          &InterceptionFunc04,
           0x48BCF - 0x48BB1
       )
   );
@@ -386,7 +374,7 @@ Enable800NewStatsButtonPatch_1_09D::MakePatches() {
       mapi::GamePatch::MakeGameBranchPatch(
           std::move(game_address_15),
           mapi::BranchType::kCall,
-          &InterceptionFunc_01,
+          &InterceptionFunc01,
           0x48808 - 0x48803
       )
   );
@@ -401,7 +389,7 @@ Enable800NewStatsButtonPatch_1_09D::MakePatches() {
       mapi::GamePatch::MakeGameBranchPatch(
           std::move(game_address_16),
           mapi::BranchType::kCall,
-          &InterceptionFunc_02,
+          &InterceptionFunc02,
           0x48861 - 0x48835
       )
   );
@@ -416,7 +404,7 @@ Enable800NewStatsButtonPatch_1_09D::MakePatches() {
       mapi::GamePatch::MakeGameBranchPatch(
           std::move(game_address_17),
           mapi::BranchType::kCall,
-          &InterceptionFunc_03,
+          &InterceptionFunc03,
           0x48891 - 0x48873
       )
   );
@@ -431,12 +419,80 @@ Enable800NewStatsButtonPatch_1_09D::MakePatches() {
       mapi::GamePatch::MakeGameBranchPatch(
           std::move(game_address_18),
           mapi::BranchType::kCall,
-          &InterceptionFunc_05,
+          &InterceptionFunc05,
           0x488AF - 0x48891
       )
   );
 
   return patches;
+}
+
+Enable800NewStatsButtonPatch_1_09D::PatchAddressAndSize
+Enable800NewStatsButtonPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x48264
+          ),
+          0x48269 - 0x48264
+      );
+    }
+  }
+}
+
+Enable800NewStatsButtonPatch_1_09D::PatchAddressAndSize
+Enable800NewStatsButtonPatch_1_09D::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x48283
+          ),
+          0x48288 - 0x48283
+      );
+    }
+  }
+}
+
+Enable800NewStatsButtonPatch_1_09D::PatchAddressAndSize
+Enable800NewStatsButtonPatch_1_09D::GetPatchAddressAndSize03() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x4831C
+          ),
+          0x4834C - 0x4831C
+      );
+    }
+  }
+}
+
+Enable800NewStatsButtonPatch_1_09D::PatchAddressAndSize
+Enable800NewStatsButtonPatch_1_09D::GetPatchAddressAndSize04() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x48524
+          ),
+          0x48529 - 0x48524
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_13c.cc
@@ -198,6 +198,19 @@ Enable800NewStatsButtonPatch_1_13C::MakePatches() {
       )
   );
 
+  // Enable drawing the New Stats button press when there are no Stat
+  // points.
+  PatchAddressAndSize patch_address_and_size_10 =
+      GetPatchAddressAndSize10();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_10.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewStatsButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_10.second
+      )
+  );
+
   return patches;
 }
 
@@ -349,6 +362,23 @@ Enable800NewStatsButtonPatch_1_13C::GetPatchAddressAndSize09() {
               0x50B8E
           ),
           0x50B93 - 0x50B8E
+      );
+    }
+  }
+}
+
+Enable800NewStatsButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewStatsButtonPatch_1_13C::GetPatchAddressAndSize10() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x50103
+          ),
+          0x50108 - 0x50103
       );
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_13c.cc
@@ -1,0 +1,357 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2client_enable_800_new_stats_button_patch_1_13c.hpp"
+
+#include "../../../asm_x86_macro.h"
+#include "d2client_enable_800_new_stats_button.hpp"
+
+namespace sgd2fr::patches::d2client {
+
+extern "C" {
+
+void __cdecl
+D2Client_Enable800NewStatsButtonPatch_1_13C_InterceptionFunc01();
+
+void __cdecl
+D2Client_Enable800NewStatsButtonPatch_1_13C_InterceptionFunc02();
+
+} // extern "C"
+
+Enable800NewStatsButtonPatch_1_13C::Enable800NewStatsButtonPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void Enable800NewStatsButtonPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void Enable800NewStatsButtonPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+std::vector<mapi::GamePatch>
+Enable800NewStatsButtonPatch_1_13C::MakePatches() {
+  ::std::vector<::mapi::GamePatch> patches;
+
+  // Enable drawing the New Stats button on the interface bar when the
+  // (Lying) Charater Screen is open or screens on both sides are
+  // open.
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewStatsButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  // Disable drawing the 640x480 "New Stats" text and New Stats button
+  // underlay on the left side.
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_02.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewStatsButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_02.second
+      )
+  );
+
+  // Enable drawing the New Stats button animation when button is
+  // pressed.
+  PatchAddressAndSize patch_address_and_size_03 =
+      GetPatchAddressAndSize03();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_03.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewStatsButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_03.second
+      )
+  );
+
+  // Enable drawing the New Stats button when there are stat points to
+  // spend.
+  PatchAddressAndSize patch_address_and_size_04 =
+      GetPatchAddressAndSize04();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_04.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewStatsButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_04.second
+      )
+  );
+
+  // Adjust the mouse position detection for New Stats button.
+  PatchAddressAndSize patch_address_and_size_05 =
+      GetPatchAddressAndSize05();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_05.first,
+          ::mapi::BranchType::kJump,
+          &D2Client_Enable800NewStatsButtonPatch_1_13C_InterceptionFunc02,
+          patch_address_and_size_05.second
+      )
+  );
+
+  // Enable additional New Stats button pressed check for mouse
+  // position detection for New Stats button press.
+  PatchAddressAndSize patch_address_and_size_06 =
+      GetPatchAddressAndSize06();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_06.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewStatsButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_06.second
+      )
+  );
+
+  // Enable use of 800x600 mouse positon detection code for New Stats
+  // button press.
+  PatchAddressAndSize patch_address_and_size_07 =
+      GetPatchAddressAndSize07();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_07.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewStatsButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_07.second
+      )
+  );
+
+  // Enable additional New Stats button pressed check for mouse
+  // position detection for New Stats button press and opening the
+  // (Lying) Charater Screen.
+  PatchAddressAndSize patch_address_and_size_08 =
+      GetPatchAddressAndSize08();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_08.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewStatsButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_08.second
+      )
+  );
+
+  // Enable use of 800x600 mouse positon detection code for New Stats
+  // button press and opening the (Lying) Charater Screen.
+  PatchAddressAndSize patch_address_and_size_09 =
+      GetPatchAddressAndSize09();
+  patches.push_back(
+      ::mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_09.first,
+          ::mapi::BranchType::kCall,
+          &D2Client_Enable800NewStatsButtonPatch_1_13C_InterceptionFunc01,
+          patch_address_and_size_09.second
+      )
+  );
+
+  return patches;
+}
+
+Enable800NewStatsButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewStatsButtonPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x50447
+          ),
+          0x5044C - 0x50447
+      );
+    }
+  }
+}
+
+Enable800NewStatsButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewStatsButtonPatch_1_13C::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x504EC
+          ),
+          0x504F1 - 0x504EC
+      );
+    }
+  }
+}
+
+Enable800NewStatsButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewStatsButtonPatch_1_13C::GetPatchAddressAndSize03() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x50563
+          ),
+          0x50568 - 0x50563
+      );
+    }
+  }
+}
+
+Enable800NewStatsButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewStatsButtonPatch_1_13C::GetPatchAddressAndSize04() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x505C8
+          ),
+          0x505CD - 0x505C8
+      );
+    }
+  }
+}
+
+Enable800NewStatsButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewStatsButtonPatch_1_13C::GetPatchAddressAndSize05() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x4FF10
+          ),
+          0x4FF55 - 0x4FF10
+      );
+    }
+  }
+}
+
+Enable800NewStatsButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewStatsButtonPatch_1_13C::GetPatchAddressAndSize06() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x5075F
+          ),
+          0x50764 - 0x5075F
+      );
+    }
+  }
+}
+
+Enable800NewStatsButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewStatsButtonPatch_1_13C::GetPatchAddressAndSize07() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x5077D
+          ),
+          0x50782 - 0x5077D
+      );
+    }
+  }
+}
+
+Enable800NewStatsButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewStatsButtonPatch_1_13C::GetPatchAddressAndSize08() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x50B70
+          ),
+          0x50B75 - 0x50B70
+      );
+    }
+  }
+}
+
+Enable800NewStatsButtonPatch_1_13C::PatchAddressAndSize
+Enable800NewStatsButtonPatch_1_13C::GetPatchAddressAndSize09() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x50B8E
+          ),
+          0x50B93 - 0x50B8E
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_13c.hpp
@@ -43,8 +43,8 @@
  *  work.
  */
 
-#ifndef SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_1_09D_HPP_
-#define SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_1_09D_HPP_
+#ifndef SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_1_13C_HPP_
 
 #include <cstddef>
 #include <utility>
@@ -54,9 +54,9 @@
 
 namespace sgd2fr::patches::d2client {
 
-class Enable800NewStatsButtonPatch_1_09D {
+class Enable800NewStatsButtonPatch_1_13C {
  public:
-  Enable800NewStatsButtonPatch_1_09D();
+  Enable800NewStatsButtonPatch_1_13C();
 
   void Apply();
   void Remove();
@@ -75,8 +75,13 @@ class Enable800NewStatsButtonPatch_1_09D {
   static PatchAddressAndSize GetPatchAddressAndSize02();
   static PatchAddressAndSize GetPatchAddressAndSize03();
   static PatchAddressAndSize GetPatchAddressAndSize04();
+  static PatchAddressAndSize GetPatchAddressAndSize05();
+  static PatchAddressAndSize GetPatchAddressAndSize06();
+  static PatchAddressAndSize GetPatchAddressAndSize07();
+  static PatchAddressAndSize GetPatchAddressAndSize08();
+  static PatchAddressAndSize GetPatchAddressAndSize09();
 };
 
 } // namespace sgd2fr::patches::d2client
 
-#endif // SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_1_09D_HPP_
+#endif // SGD2FR_PATCHES_INTERFACE_BAR_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_D2CLIENT_ENABLE_800_NEW_STATS_BUTTON_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_13c.hpp
@@ -80,6 +80,7 @@ class Enable800NewStatsButtonPatch_1_13C {
   static PatchAddressAndSize GetPatchAddressAndSize07();
   static PatchAddressAndSize GetPatchAddressAndSize08();
   static PatchAddressAndSize GetPatchAddressAndSize09();
+  static PatchAddressAndSize GetPatchAddressAndSize10();
 };
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_13c_shim.asm
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_13c_shim.asm
@@ -1,0 +1,90 @@
+;
+; SlashGaming Diablo II Free Resolution
+; Copyright (C) 2019-2021  Mir Drualga
+;
+; This file is part of SlashGaming Diablo II Free Resolution.
+;
+;  This program is free software: you can redistribute it and/or modify
+;  it under the terms of the GNU Affero General Public License as published
+;  by the Free Software Foundation, either version 3 of the License, or
+;  (at your option) any later version.
+;
+;  This program is distributed in the hope that it will be useful,
+;  but WITHOUT ANY WARRANTY; without even the implied warranty of
+;  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;  GNU Affero General Public License for more details.
+;
+;  You should have received a copy of the GNU Affero General Public License
+;  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;
+;  Additional permissions under GNU Affero General Public License version 3
+;  section 7
+;
+;  If you modify this Program, or any covered work, by linking or combining
+;  it with Diablo II (or a modified version of that game and its
+;  libraries), containing parts covered by the terms of Blizzard End User
+;  License Agreement, the licensors of this Program grant you additional
+;  permission to convey the resulting work. This additional permission is
+;  also extended to any combination of expansions, mods, and remasters of
+;  the game.
+;
+;  If you modify this Program, or any covered work, by linking or combining
+;  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+;  Glide, OpenGL, or Rave wrapper (or modified versions of those
+;  libraries), containing parts not covered by a compatible license, the
+;  licensors of this Program grant you additional permission to convey the
+;  resulting work.
+;
+;  If you modify this Program, or any covered work, by linking or combining
+;  it with any library (or a modified version of that library) that links
+;  to Diablo II (or a modified version of that game and its libraries),
+;  containing parts not covered by a compatible license, the licensors of
+;  this Program grant you additional permission to convey the resulting
+;  work.
+;
+
+global _D2Client_Enable800NewStatsButtonPatch_1_13C_InterceptionFunc01
+global _D2Client_Enable800NewStatsButtonPatch_1_13C_InterceptionFunc02
+
+extern _Sgd2fr_D2Client_Get800NewStatsButtonEnabledValue
+extern _Sgd2fr_D2Client_IsMouseOver800NewStatsButton
+
+section .data
+
+section .bss
+
+section .text
+
+;
+; External
+;
+
+_D2Client_Enable800NewStatsButtonPatch_1_13C_InterceptionFunc01:
+    push ebp
+    mov ebp, esp
+
+    push ecx
+    push edx
+
+    call _Sgd2fr_D2Client_Get800NewStatsButtonEnabledValue
+
+    pop edx
+    pop ecx
+
+    leave
+    ret
+
+_D2Client_Enable800NewStatsButtonPatch_1_13C_InterceptionFunc02:
+    push ebp
+    mov ebp, esp
+
+    push ecx
+    push edx
+
+    call _Sgd2fr_D2Client_IsMouseOver800NewStatsButton
+
+    pop edx
+    pop ecx
+
+    leave
+    ret

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_belt_record_patch/d2common_get_global_belt_record_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_belt_record_patch/d2common_get_global_belt_record_patch.cc
@@ -68,7 +68,8 @@ GetGlobalBeltRecordPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case d2::GameVersion::k1_09D: {
+    case d2::GameVersion::k1_09D:
+    case d2::GameVersion::k1_13C: {
       return GetGlobalBeltRecordPatch_1_09D();
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_belt_record_patch/d2common_get_global_belt_record_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_belt_record_patch/d2common_get_global_belt_record_patch_1_09d.cc
@@ -45,15 +45,13 @@
 
 #include "d2common_get_global_belt_record_patch_1_09d.hpp"
 
-#include <unordered_map>
-
 #include "../../../asm_x86_macro.h"
 #include "d2common_get_global_belt_record.hpp"
 
 namespace sgd2fr::patches::d2common {
 namespace {
 
-__declspec(naked) void __cdecl InterceptionFunc_01() {
+__declspec(naked) void __cdecl InterceptionFunc01() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -93,38 +91,49 @@ void GetGlobalBeltRecordPatch_1_09D::Remove() {
   }
 }
 
-const mapi::GameAddress&
-GetGlobalBeltRecordPatch_1_09D::GetPatchAddress() {
-  static const std::unordered_map<
-      d2::GameVersion,
-      mapi::GameAddress
-  > kPatchAddresses = {
-      {
-          d2::GameVersion::k1_09D,
-          mapi::GameAddress::FromOrdinal(
-              ::d2::DefaultLibrary::kD2Common,
-              10638
-          )
-      }
-  };
-
-  return kPatchAddresses.at(::d2::game_version::GetRunning());
-}
-
 std::vector<mapi::GamePatch>
 GetGlobalBeltRecordPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          GetPatchAddress(),
+          patch_address_and_size_01.first,
           mapi::BranchType::kJump,
-          &InterceptionFunc_01,
-          5
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
       )
   );
 
   return patches;
+}
+
+GetGlobalBeltRecordPatch_1_09D::PatchAddressAndSize
+GetGlobalBeltRecordPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOrdinal(
+              ::d2::DefaultLibrary::kD2Common,
+              10638
+          ),
+          5
+      );
+    }
+
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOrdinal(
+              ::d2::DefaultLibrary::kD2Common,
+              10991
+          ),
+          5
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2common

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_belt_record_patch/d2common_get_global_belt_record_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_belt_record_patch/d2common_get_global_belt_record_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_INVENTORY_D2COMMON_GET_GLOBAL_BELT_RECORD_PATCH_D2COMMON_GET_GLOBAL_BELT_RECORD_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_INVENTORY_D2COMMON_GET_GLOBAL_BELT_RECORD_PATCH_D2COMMON_GET_GLOBAL_BELT_RECORD_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,10 +62,16 @@ class GetGlobalBeltRecordPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
-  static const mapi::GameAddress& GetPatchAddress();
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
 };
 
 } // namespace sgd2fr::patches

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_belt_slot_position_patch/d2common_get_global_belt_slot_position_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_belt_slot_position_patch/d2common_get_global_belt_slot_position_patch.cc
@@ -68,7 +68,8 @@ GetGlobalBeltSlotPositionPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case ::d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_09D:
+    case ::d2::GameVersion::k1_13C: {
       return GetGlobalBeltSlotPositionPatch_1_09D();
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_belt_slot_position_patch/d2common_get_global_belt_slot_position_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_belt_slot_position_patch/d2common_get_global_belt_slot_position_patch_1_09d.cc
@@ -45,15 +45,13 @@
 
 #include "d2common_get_global_belt_slot_position_patch_1_09d.hpp"
 
-#include <unordered_map>
-
 #include "../../../asm_x86_macro.h"
 #include "d2common_get_global_belt_slot_position.hpp"
 
 namespace sgd2fr::patches::d2common {
 namespace {
 
-__declspec(naked) void __cdecl InterceptionFunc_01() {
+__declspec(naked) void __cdecl InterceptionFunc01() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -94,38 +92,49 @@ void GetGlobalBeltSlotPositionPatch_1_09D::Remove() {
   }
 }
 
-const mapi::GameAddress&
-GetGlobalBeltSlotPositionPatch_1_09D::GetPatchAddress() {
-  static const std::unordered_map<
-      d2::GameVersion,
-      mapi::GameAddress
-  > kPatchAddresses = {
-      {
-          d2::GameVersion::k1_09D,
-          mapi::GameAddress::FromOrdinal(
-              ::d2::DefaultLibrary::kD2Common,
-              10639
-          )
-      }
-  };
-
-  return kPatchAddresses.at(::d2::game_version::GetRunning());
-}
-
 std::vector<mapi::GamePatch>
 GetGlobalBeltSlotPositionPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          GetPatchAddress(),
+          patch_address_and_size_01.first,
           mapi::BranchType::kJump,
-          &InterceptionFunc_01,
-          5
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
       )
   );
 
   return patches;
+}
+
+GetGlobalBeltSlotPositionPatch_1_09D::PatchAddressAndSize
+GetGlobalBeltSlotPositionPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOrdinal(
+              ::d2::DefaultLibrary::kD2Common,
+              10639
+          ),
+          5
+      );
+    }
+
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOrdinal(
+              ::d2::DefaultLibrary::kD2Common,
+              10333
+          ),
+          5
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2common

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_belt_slot_position_patch/d2common_get_global_belt_slot_position_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_belt_slot_position_patch/d2common_get_global_belt_slot_position_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_INVENTORY_D2COMMON_GET_GLOBAL_BELT_SLOT_POSITION_PATCH_D2COMMON_GET_GLOBAL_BELT_SLOT_POSITION_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_INVENTORY_D2COMMON_GET_GLOBAL_BELT_SLOT_POSITION_PATCH_D2COMMON_GET_GLOBAL_BELT_SLOT_POSITION_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,10 +62,16 @@ class GetGlobalBeltSlotPositionPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
-  static const mapi::GameAddress& GetPatchAddress();
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
 };
 
 } // namespace sgd2fr::patches::d2common

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_equipment_slot_layout_patch/d2common_get_global_equipment_slot_layout_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_equipment_slot_layout_patch/d2common_get_global_equipment_slot_layout_patch.cc
@@ -68,7 +68,8 @@ GetGlobalEquipmentSlotLayoutPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case ::d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_09D:
+    case ::d2::GameVersion::k1_13C: {
       return GetGlobalEquipmentSlotLayoutPatch_1_09D();
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_equipment_slot_layout_patch/d2common_get_global_equipment_slot_layout_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_equipment_slot_layout_patch/d2common_get_global_equipment_slot_layout_patch_1_09d.cc
@@ -45,15 +45,13 @@
 
 #include "d2common_get_global_equipment_slot_layout_patch_1_09d.hpp"
 
-#include <unordered_map>
-
 #include "../../../asm_x86_macro.h"
 #include "d2common_get_global_equipment_slot_layout.hpp"
 
 namespace sgd2fr::patches::d2common {
 namespace {
 
-__declspec(naked) void __cdecl InterceptionFunc_01() {
+__declspec(naked) void __cdecl InterceptionFunc01() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -95,38 +93,49 @@ void GetGlobalEquipmentSlotLayoutPatch_1_09D::Remove() {
   }
 }
 
-const mapi::GameAddress&
-GetGlobalEquipmentSlotLayoutPatch_1_09D::GetPatchAddress() {
-  static const std::unordered_map<
-      d2::GameVersion,
-      mapi::GameAddress
-  > kPatchAddresses = {
-      {
-          d2::GameVersion::k1_09D,
-          mapi::GameAddress::FromOrdinal(
-              ::d2::DefaultLibrary::kD2Common,
-              10637
-          )
-      }
-  };
-
-  return kPatchAddresses.at(::d2::game_version::GetRunning());
-}
-
 std::vector<mapi::GamePatch>
 GetGlobalEquipmentSlotLayoutPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          GetPatchAddress(),
+          patch_address_and_size_01.first,
           mapi::BranchType::kJump,
-          &InterceptionFunc_01,
-          5
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
       )
   );
 
   return patches;
+}
+
+GetGlobalEquipmentSlotLayoutPatch_1_09D::PatchAddressAndSize
+GetGlobalEquipmentSlotLayoutPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOrdinal(
+              ::d2::DefaultLibrary::kD2Common,
+              10637
+          ),
+          5
+      );
+    }
+
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOrdinal(
+              ::d2::DefaultLibrary::kD2Common,
+              10701
+          ),
+          5
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2common

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_equipment_slot_layout_patch/d2common_get_global_equipment_slot_layout_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_equipment_slot_layout_patch/d2common_get_global_equipment_slot_layout_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_INVENTORY_D2COMMON_GET_GLOBAL_EQUIPMENT_SLOT_LAYOUT_PATCH_D2COMMON_GET_GLOBAL_EQUIPMENT_SLOT_LAYOUT_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_INVENTORY_D2COMMON_GET_GLOBAL_EQUIPMENT_SLOT_LAYOUT_PATCH_D2COMMON_GET_GLOBAL_EQUIPMENT_SLOT_LAYOUT_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,10 +62,16 @@ class GetGlobalEquipmentSlotLayoutPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
-  static const mapi::GameAddress& GetPatchAddress();
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
 };
 
 } // namespace sgd2fr::patches::d2common

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_inventory_grid_layout_patch/d2common_get_global_inventory_grid_layout_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_inventory_grid_layout_patch/d2common_get_global_inventory_grid_layout_patch.cc
@@ -68,7 +68,8 @@ GetGlobalInventoryGridLayoutPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case d2::GameVersion::k1_09D: {
+    case d2::GameVersion::k1_09D:
+    case d2::GameVersion::k1_13C: {
       return GetGlobalInventoryGridLayoutPatch_1_09D();
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_inventory_grid_layout_patch/d2common_get_global_inventory_grid_layout_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_inventory_grid_layout_patch/d2common_get_global_inventory_grid_layout_patch_1_09d.cc
@@ -45,15 +45,13 @@
 
 #include "d2common_get_global_inventory_grid_layout_patch_1_09d.hpp"
 
-#include <unordered_map>
-
 #include "../../../asm_x86_macro.h"
 #include "d2common_get_global_inventory_grid_layout.hpp"
 
 namespace sgd2fr::patches::d2common {
 namespace {
 
-__declspec(naked) void __cdecl InterceptionFunc_01() {
+__declspec(naked) void __cdecl InterceptionFunc01() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -94,38 +92,49 @@ void GetGlobalInventoryGridLayoutPatch_1_09D::Remove() {
   }
 }
 
-const mapi::GameAddress&
-GetGlobalInventoryGridLayoutPatch_1_09D::GetPatchAddress() {
-  static const std::unordered_map<
-      d2::GameVersion,
-      mapi::GameAddress
-  > kPatchAddresses = {
-      {
-          d2::GameVersion::k1_09D,
-          mapi::GameAddress::FromOrdinal(
-              ::d2::DefaultLibrary::kD2Common,
-              10636
-          )
-      }
-  };
-
-  return kPatchAddresses.at(::d2::game_version::GetRunning());
-}
-
 std::vector<mapi::GamePatch>
 GetGlobalInventoryGridLayoutPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          GetPatchAddress(),
+          patch_address_and_size_01.first,
           mapi::BranchType::kJump,
-          &InterceptionFunc_01,
-          5
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
       )
   );
 
   return patches;
+}
+
+GetGlobalInventoryGridLayoutPatch_1_09D::PatchAddressAndSize
+GetGlobalInventoryGridLayoutPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOrdinal(
+              ::d2::DefaultLibrary::kD2Common,
+              10636
+          ),
+          5
+      );
+    }
+
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOrdinal(
+              ::d2::DefaultLibrary::kD2Common,
+              10760
+          ),
+          5
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2common

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_inventory_grid_layout_patch/d2common_get_global_inventory_grid_layout_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_inventory_grid_layout_patch/d2common_get_global_inventory_grid_layout_patch_1_09d.hpp
@@ -60,10 +60,16 @@ class GetGlobalInventoryGridLayoutPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
-  static const mapi::GameAddress& GetPatchAddress();
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
 };
 
 } // namespace sgd2fr::patches::d2common

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_inventory_position_patch/d2common_get_global_inventory_position_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_inventory_position_patch/d2common_get_global_inventory_position_patch.cc
@@ -68,7 +68,8 @@ GetGlobalInventoryPositionPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case d2::GameVersion::k1_09D: {
+    case d2::GameVersion::k1_09D:
+    case d2::GameVersion::k1_13C: {
       return GetGlobalInventoryPositionPatch_1_09D();
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_inventory_position_patch/d2common_get_global_inventory_position_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_inventory_position_patch/d2common_get_global_inventory_position_patch_1_09d.cc
@@ -45,15 +45,13 @@
 
 #include "d2common_get_global_inventory_position_patch_1_09d.hpp"
 
-#include <unordered_map>
-
 #include "../../../asm_x86_macro.h"
 #include "d2common_get_global_inventory_position.hpp"
 
 namespace sgd2fr::patches::d2common {
 namespace {
 
-__declspec(naked) void __cdecl InterceptionFunc_01() {
+__declspec(naked) void __cdecl InterceptionFunc01() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -94,38 +92,49 @@ void GetGlobalInventoryPositionPatch_1_09D::Remove() {
   }
 }
 
-const mapi::GameAddress&
-GetGlobalInventoryPositionPatch_1_09D::GetPatchAddress() {
-  static const std::unordered_map<
-      d2::GameVersion,
-      mapi::GameAddress
-  > kPatchAddresses = {
-      {
-          d2::GameVersion::k1_09D,
-          mapi::GameAddress::FromOrdinal(
-              ::d2::DefaultLibrary::kD2Common,
-              10635
-          )
-      }
-  };
-
-  return kPatchAddresses.at(::d2::game_version::GetRunning());
-}
-
 std::vector<mapi::GamePatch>
 GetGlobalInventoryPositionPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          GetPatchAddress(),
+          patch_address_and_size_01.first,
           mapi::BranchType::kJump,
-          &InterceptionFunc_01,
-          5
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
       )
   );
 
   return patches;
+}
+
+GetGlobalInventoryPositionPatch_1_09D::PatchAddressAndSize
+GetGlobalInventoryPositionPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOrdinal(
+              ::d2::DefaultLibrary::kD2Common,
+              10635
+          ),
+          5
+      );
+    }
+
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOrdinal(
+              ::d2::DefaultLibrary::kD2Common,
+              11012
+          ),
+          5
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2common

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_inventory_position_patch/d2common_get_global_inventory_position_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/inventory/d2common_get_global_inventory_position_patch/d2common_get_global_inventory_position_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_INVENTORY_D2COMMON_GET_GLOBAL_INVENTORY_POSITION_PATCH_D2COMMON_GET_GLOBAL_INVENTORY_POSITION_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_INVENTORY_D2COMMON_GET_GLOBAL_INVENTORY_POSITION_PATCH_D2COMMON_GET_GLOBAL_INVENTORY_POSITION_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,10 +62,16 @@ class GetGlobalInventoryPositionPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
-  static const mapi::GameAddress& GetPatchAddress();
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
 };
 
 } // namespace sgd2fr::patches::d2common

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch.cc
@@ -71,6 +71,10 @@ DisableMouseClickOnScreenPatch::MakePatch() {
     case d2::GameVersion::k1_09D: {
       return DisableMouseClickOnScreenPatch_1_09D();
     }
+
+    case d2::GameVersion::k1_13C: {
+      return DisableMouseClickOnScreenPatch_1_13C();
+    }
   }
 }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch.hpp
@@ -50,13 +50,15 @@
 
 #include <sgd2mapi.hpp>
 #include "d2client_disable_mouse_click_on_screen_patch_1_09d.hpp"
+#include "d2client_disable_mouse_click_on_screen_patch_1_13c.hpp"
 
 namespace sgd2fr::patches::d2client {
 
 class DisableMouseClickOnScreenPatch {
  public:
   using PatchVariant = std::variant<
-      DisableMouseClickOnScreenPatch_1_09D
+      DisableMouseClickOnScreenPatch_1_09D,
+      DisableMouseClickOnScreenPatch_1_13C
   >;
 
   DisableMouseClickOnScreenPatch();

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch_1_09d.cc
@@ -69,46 +69,88 @@ std::vector<mapi::GamePatch>
 DisableMouseClickOnScreenPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
-  // Disable left screen click-through.
-  mapi::GameAddress game_address_01 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x2AB1A
-  );
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
+  // Disable left screen click-through.
+  PatchAddressAndSize patch_address_and_size_01 = GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameNopPatch(
-          std::move(game_address_01),
-          0x2AB24 - 0x2AB1A
+          patch_address_and_size_01.first,
+          patch_address_and_size_01.second
       )
   );
 
   // Disable left screen click-through while character is moving.
-  mapi::GameAddress game_address_02 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x2AD1A
-  );
-
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
   patches.push_back(
       mapi::GamePatch::MakeGameNopPatch(
-          std::move(game_address_02),
-          0x2AD24 - 0x2AD1A
+          patch_address_and_size_02.first,
+          patch_address_and_size_02.second
       )
   );
 
   // Disable right screen click-through.
-  mapi::GameAddress game_address_03 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x40873
-  );
-
+  PatchAddressAndSize patch_address_and_size_03 = GetPatchAddressAndSize03();
   patches.push_back(
       mapi::GamePatch::MakeGameNopPatch(
-          std::move(game_address_03),
-          0x40881 - 0x40873
+          patch_address_and_size_03.first,
+          patch_address_and_size_03.second
       )
   );
 
   return patches;
+}
+
+DisableMouseClickOnScreenPatch_1_09D::PatchAddressAndSize
+DisableMouseClickOnScreenPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x2AB1A
+          ),
+          0x2AB24 - 0x2AB1A
+      );
+    }
+  }
+}
+
+DisableMouseClickOnScreenPatch_1_09D::PatchAddressAndSize
+DisableMouseClickOnScreenPatch_1_09D::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x2AD1A
+          ),
+          0x2AD24 - 0x2AD1A
+      );
+    }
+  }
+}
+
+DisableMouseClickOnScreenPatch_1_09D::PatchAddressAndSize
+DisableMouseClickOnScreenPatch_1_09D::GetPatchAddressAndSize03() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x40873
+          ),
+          0x40881 - 0x40873
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_REQUIRED_D2CLIENT_DISABLE_MOUSE_CLICK_ON_SCREEN_PATCH_D2CLIENT_DISABLE_MOUSE_CLICK_ON_SCREEN_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_REQUIRED_D2CLIENT_DISABLE_MOUSE_CLICK_ON_SCREEN_PATCH_D2CLIENT_DISABLE_MOUSE_CLICK_ON_SCREEN_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,9 +62,18 @@ class DisableMouseClickOnScreenPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
+  static PatchAddressAndSize GetPatchAddressAndSize03();
 };
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch_1_13c.cc
@@ -1,0 +1,129 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2client_disable_mouse_click_on_screen_patch_1_13c.hpp"
+
+#include "../../../asm_x86_macro.h"
+
+namespace sgd2fr::patches::d2client {
+
+DisableMouseClickOnScreenPatch_1_13C::DisableMouseClickOnScreenPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void DisableMouseClickOnScreenPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void DisableMouseClickOnScreenPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Remove();
+  }
+}
+
+std::vector<mapi::GamePatch>
+DisableMouseClickOnScreenPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  // Disable left screen click-through.
+  PatchAddressAndSize patch_address_and_size_01 = GetPatchAddressAndSize01();
+  patches.push_back(
+      mapi::GamePatch::MakeGameNopPatch(
+          patch_address_and_size_01.first,
+          patch_address_and_size_01.second
+      )
+  );
+
+  // Disable right screen click-through.
+  PatchAddressAndSize patch_address_and_size_02 = GetPatchAddressAndSize02();
+  patches.push_back(
+      mapi::GamePatch::MakeGameNopPatch(
+          patch_address_and_size_02.first,
+          patch_address_and_size_02.second
+      )
+  );
+
+  return patches;
+}
+
+DisableMouseClickOnScreenPatch_1_13C::PatchAddressAndSize
+DisableMouseClickOnScreenPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0xBCB30
+          ),
+          0xBCB3A - 0xBCB30
+      );
+    }
+  }
+}
+
+DisableMouseClickOnScreenPatch_1_13C::PatchAddressAndSize
+DisableMouseClickOnScreenPatch_1_13C::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x8F880
+          ),
+          0x8F88A - 0x8F880
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch_1_13c.hpp
@@ -1,0 +1,80 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2CLIENT_DISABLE_MOUSE_CLICK_ON_SCREEN_PATCH_D2CLIENT_DISABLE_MOUSE_CLICK_ON_SCREEN_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2CLIENT_DISABLE_MOUSE_CLICK_ON_SCREEN_PATCH_D2CLIENT_DISABLE_MOUSE_CLICK_ON_SCREEN_PATCH_1_13C_HPP_
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr::patches::d2client {
+
+class DisableMouseClickOnScreenPatch_1_13C {
+ public:
+  DisableMouseClickOnScreenPatch_1_13C();
+
+  void Apply();
+  void Remove();
+
+ private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
+  std::vector<mapi::GamePatch> patches_;
+
+  static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
+};
+
+} // namespace sgd2fr::patches::d2client
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2CLIENT_DISABLE_MOUSE_CLICK_ON_SCREEN_PATCH_D2CLIENT_DISABLE_MOUSE_CLICK_ON_SCREEN_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text.cc
@@ -75,6 +75,20 @@ mapi::bool32 __cdecl Sgd2fr_D2Client_DrawResolutionText(
       comparing_cel_file_base_address = reinterpret_cast<d2::CelFile*>(
           raw_address
       );
+
+      break;
+    }
+
+    case ::d2::GameVersion::k1_13C: {
+      std::intptr_t raw_address = mapi::GameAddress::FromOffset(
+          ::d2::DefaultLibrary::kD2Client,
+          0xEA568
+      ).raw_address();
+
+      comparing_cel_file_base_address = reinterpret_cast<d2::CelFile*>(
+          raw_address
+      );
+
       break;
     }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch.cc
@@ -68,8 +68,12 @@ DrawResolutionTextPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_09D: {
       return DrawResolutionTextPatch_1_09D();
+    }
+
+    case ::d2::GameVersion::k1_13C: {
+      return DrawResolutionTextPatch_1_13C();
     }
   }
 }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch.hpp
@@ -50,13 +50,15 @@
 
 #include <sgd2mapi.hpp>
 #include "d2client_draw_resolution_text_patch_1_09d.hpp"
+#include "d2client_draw_resolution_text_patch_1_13c.hpp"
 
 namespace sgd2fr::patches::d2client {
 
 class DrawResolutionTextPatch {
  public:
   using PatchVariant = std::variant<
-      DrawResolutionTextPatch_1_09D
+      DrawResolutionTextPatch_1_09D,
+      DrawResolutionTextPatch_1_13C
   >;
 
   DrawResolutionTextPatch();

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_1_09d.cc
@@ -51,7 +51,7 @@
 namespace sgd2fr::patches::d2client {
 namespace {
 
-__declspec(naked) void __cdecl InterceptionFunc_01() {
+__declspec(naked) void __cdecl InterceptionFunc01() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -109,21 +109,37 @@ std::vector<mapi::GamePatch>
 DrawResolutionTextPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
-  mapi::GameAddress game_address_01 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x62627
-  );
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          std::move(game_address_01),
+          patch_address_and_size_01.first,
           mapi::BranchType::kCall,
-          &InterceptionFunc_01,
-          0x6262D - 0x62627
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
       )
   );
 
   return patches;
+}
+
+DrawResolutionTextPatch_1_09D::PatchAddressAndSize
+DrawResolutionTextPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x62627
+          ),
+          0x6262D - 0x62627
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_REQUIRED_D2CLIENT_DRAW_RESOLUTION_TEXT_PATCH_D2CLIENT_DRAW_RESOLUTION_TEXT_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_REQUIRED_D2CLIENT_DRAW_RESOLUTION_TEXT_PATCH_D2CLIENT_DRAW_RESOLUTION_TEXT_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,9 +62,16 @@ class DrawResolutionTextPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
 };
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_1_13c.cc
@@ -1,0 +1,143 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2client_draw_resolution_text_patch_1_13c.hpp"
+
+#include "../../../asm_x86_macro.h"
+#include "d2client_draw_resolution_text.hpp"
+
+namespace sgd2fr::patches::d2client {
+namespace {
+
+__declspec(naked) void __cdecl InterceptionFunc01() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  // Original code
+  ASM_X86(add edx, 230);
+
+  ASM_X86(push eax);
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(push ebx);
+  ASM_X86(push edx);
+  ASM_X86(push esi);
+  ASM_X86(push eax);
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2Client_DrawResolutionText));
+  ASM_X86(add esp, 16);
+
+  // If the correct pieces executed, then remove the pushed arguments, then
+  // set the return address to a place after the original draw function call.
+  ASM_X86(test eax, eax);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+  ASM_X86(pop eax);
+
+  ASM_X86(leave);
+
+  ASM_X86(jnz DidDrawUnicodeText);
+  ASM_X86(ret);
+
+DidDrawUnicodeText:
+  ASM_X86(add dword ptr [esp], 6);
+  ASM_X86(ret 16);
+}
+
+} // namespace
+
+DrawResolutionTextPatch_1_13C::DrawResolutionTextPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void DrawResolutionTextPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void DrawResolutionTextPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+std::vector<mapi::GamePatch>
+DrawResolutionTextPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  return patches;
+}
+
+DrawResolutionTextPatch_1_13C::PatchAddressAndSize
+DrawResolutionTextPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+        ::mapi::GameAddress::FromOffset(
+            ::d2::DefaultLibrary::kD2Client,
+            0x65407
+        ),
+        0x6540D - 0x65407
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_1_13c.hpp
@@ -1,0 +1,79 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2CLIENT_DRAW_RESOLUTION_TEXT_PATCH_D2CLIENT_DRAW_RESOLUTION_TEXT_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2CLIENT_DRAW_RESOLUTION_TEXT_PATCH_D2CLIENT_DRAW_RESOLUTION_TEXT_PATCH_1_13C_HPP_
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr::patches::d2client {
+
+class DrawResolutionTextPatch_1_13C {
+ public:
+  DrawResolutionTextPatch_1_13C();
+
+  void Apply();
+  void Remove();
+
+ private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
+  std::vector<mapi::GamePatch> patches_;
+
+  static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+};
+
+} // namespace sgd2fr::patches::d2client
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2CLIENT_DRAW_RESOLUTION_TEXT_PATCH_D2CLIENT_DRAW_RESOLUTION_TEXT_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch.cc
@@ -71,6 +71,10 @@ GetResolutionRegistryPatch::MakePatch() {
     case d2::GameVersion::k1_09D: {
       return GetResolutionRegistryPatch_1_09D();
     }
+
+    case d2::GameVersion::k1_13C: {
+      return GetResolutionRegistryPatch_1_13C();
+    }
   }
 }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch.hpp
@@ -50,13 +50,15 @@
 
 #include <sgd2mapi.hpp>
 #include "d2client_get_resolution_registry_patch_1_09d.hpp"
+#include "d2client_get_resolution_registry_patch_1_13c.hpp"
 
 namespace sgd2fr::patches::d2client {
 
 class GetResolutionRegistryPatch {
  public:
   using PatchVariant = std::variant<
-      GetResolutionRegistryPatch_1_09D
+      GetResolutionRegistryPatch_1_09D,
+      GetResolutionRegistryPatch_1_13C
   >;
 
   GetResolutionRegistryPatch();

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_1_09d.cc
@@ -51,7 +51,7 @@
 namespace sgd2fr::patches::d2client {
 namespace {
 
-__declspec(naked) void __cdecl InterceptionFunc_01() {
+__declspec(naked) void __cdecl InterceptionFunc01() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -75,7 +75,7 @@ __declspec(naked) void __cdecl InterceptionFunc_01() {
   ASM_X86(ret);
 }
 
-__declspec(naked) void __cdecl InterceptionFunc_03() {
+__declspec(naked) void __cdecl InterceptionFunc03() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -123,47 +123,89 @@ std::vector<mapi::GamePatch>
 GetResolutionRegistryPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
-  mapi::GameAddress game_address_01 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x61097
-  );
-
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          std::move(game_address_01),
+          patch_address_and_size_01.first,
           mapi::BranchType::kCall,
-          &InterceptionFunc_01,
-          0x610AE - 0x61097
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
       )
   );
 
-  mapi::GameAddress game_address_02 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x610AF
-  );
-
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
   patches.push_back(
       mapi::GamePatch::MakeGameNopPatch(
-          std::move(game_address_02),
-          0x610B6 - 0x610AF
+          patch_address_and_size_02.first,
+          patch_address_and_size_02.second
       )
   );
 
-  mapi::GameAddress game_address_03 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x63885
-  );
-
+  PatchAddressAndSize patch_address_and_size_03 =
+      GetPatchAddressAndSize03();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          std::move(game_address_03),
+          patch_address_and_size_03.first,
           mapi::BranchType::kCall,
-          &InterceptionFunc_03,
-          0x638A5 - 0x63885
+          &InterceptionFunc03,
+          patch_address_and_size_03.second
       )
   );
 
   return patches;
+}
+
+GetResolutionRegistryPatch_1_09D::PatchAddressAndSize
+GetResolutionRegistryPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x61097
+          ),
+          0x610AE - 0x61097
+      );
+    }
+  }
+}
+
+GetResolutionRegistryPatch_1_09D::PatchAddressAndSize
+GetResolutionRegistryPatch_1_09D::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x610AF
+          ),
+          0x610B6 - 0x610AF
+      );
+    }
+  }
+}
+
+GetResolutionRegistryPatch_1_09D::PatchAddressAndSize
+GetResolutionRegistryPatch_1_09D::GetPatchAddressAndSize03() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x63885
+          ),
+          0x638A5 - 0x63885
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_REQUIRED_D2CLIENT_GET_RESOLUTION_REGISTRY_PATCH_D2CLIENT_GET_RESOLUTION_REGISTRY_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_REQUIRED_D2CLIENT_GET_RESOLUTION_REGISTRY_PATCH_D2CLIENT_GET_RESOLUTION_REGISTRY_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,9 +62,18 @@ class GetResolutionRegistryPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
+  static PatchAddressAndSize GetPatchAddressAndSize03();
 };
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_1_13c.cc
@@ -1,0 +1,275 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2client_get_resolution_registry_patch_1_13c.hpp"
+
+#include "../../../asm_x86_macro.h"
+#include "d2client_get_resolution_registry.hpp"
+
+namespace sgd2fr::patches::d2client {
+namespace {
+
+__declspec(naked) void __cdecl InterceptionFunc01() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(sub esp, 4);
+
+  ASM_X86(push eax);
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(lea ecx, dword ptr [ebp - 4]);
+  ASM_X86(push ecx);
+  ASM_X86(push eax);
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2Client_GetResolutionRegistry));
+  ASM_X86(add esp, 8);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+  ASM_X86(pop eax);
+
+  ASM_X86(mov esi, dword ptr [ebp - 4]);
+
+  ASM_X86(add esp, 4);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+__declspec(naked) void __cdecl InterceptionFunc03() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(sub esp, 4);
+
+  ASM_X86(push eax);
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(lea ecx, dword ptr [ebp - 4]);
+  ASM_X86(push ecx);
+  ASM_X86(push edi);
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2Client_GetResolutionRegistry));
+  ASM_X86(add esp, 8);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+  ASM_X86(pop eax);
+
+  ASM_X86(mov esi, dword ptr [ebp - 4]);
+
+  ASM_X86(add esp, 4);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+__declspec(naked) void __cdecl InterceptionFunc04() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(sub esp, 4);
+
+  ASM_X86(push eax);
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(lea eax, dword ptr [ebp - 4]);
+  ASM_X86(push eax);
+  ASM_X86(push ecx);
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2Client_GetResolutionRegistry));
+  ASM_X86(add esp, 8);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+  ASM_X86(pop eax);
+
+  ASM_X86(mov esi, dword ptr [ebp - 4]);
+
+  ASM_X86(add esp, 4);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+} // namespace
+
+GetResolutionRegistryPatch_1_13C::GetResolutionRegistryPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void GetResolutionRegistryPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void GetResolutionRegistryPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+std::vector<mapi::GamePatch>
+GetResolutionRegistryPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_02.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc01,
+          patch_address_and_size_02.second
+      )
+  );
+
+  PatchAddressAndSize patch_address_and_size_03 =
+      GetPatchAddressAndSize03();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_03.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc03,
+          patch_address_and_size_03.second
+      )
+  );
+
+  PatchAddressAndSize patch_address_and_size_04 =
+      GetPatchAddressAndSize04();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_04.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc04,
+          patch_address_and_size_04.second
+      )
+  );
+
+  return patches;
+}
+
+GetResolutionRegistryPatch_1_13C::PatchAddressAndSize
+GetResolutionRegistryPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x44453
+          ),
+          0x44472 - 0x44453
+      );
+    }
+  }
+}
+
+GetResolutionRegistryPatch_1_13C::PatchAddressAndSize
+GetResolutionRegistryPatch_1_13C::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x65E46
+          ),
+          0x65E66 - 0x65E46
+      );
+    }
+  }
+}
+
+GetResolutionRegistryPatch_1_13C::PatchAddressAndSize
+GetResolutionRegistryPatch_1_13C::GetPatchAddressAndSize03() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x66278
+          ),
+          0x66296 - 0x66278
+      );
+    }
+  }
+}
+
+GetResolutionRegistryPatch_1_13C::PatchAddressAndSize
+GetResolutionRegistryPatch_1_13C::GetPatchAddressAndSize04() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0xAF950
+          ),
+          0xAF970 - 0xAF950
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_1_13c.hpp
@@ -1,0 +1,82 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2CLIENT_GET_RESOLUTION_REGISTRY_PATCH_D2CLIENT_GET_RESOLUTION_REGISTRY_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2CLIENT_GET_RESOLUTION_REGISTRY_PATCH_D2CLIENT_GET_RESOLUTION_REGISTRY_PATCH_1_13C_HPP_
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr::patches::d2client {
+
+class GetResolutionRegistryPatch_1_13C {
+ public:
+  GetResolutionRegistryPatch_1_13C();
+
+  void Apply();
+  void Remove();
+
+ private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
+  std::vector<mapi::GamePatch> patches_;
+
+  static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
+  static PatchAddressAndSize GetPatchAddressAndSize03();
+  static PatchAddressAndSize GetPatchAddressAndSize04();
+};
+
+} // namespace sgd2fr::patches::d2client
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2CLIENT_GET_RESOLUTION_REGISTRY_PATCH_D2CLIENT_GET_RESOLUTION_REGISTRY_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_general_display_width_and_height_patch/d2client_set_general_display_width_and_height_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_general_display_width_and_height_patch/d2client_set_general_display_width_and_height_patch.cc
@@ -68,7 +68,8 @@ SetGeneralDisplayWidthAndHeightPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_09D:
+    case ::d2::GameVersion::k1_13C: {
       return SetGeneralDisplayWidthAndHeightPatch_1_09D();
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_general_display_width_and_height_patch/d2client_set_general_display_width_and_height_patch_1_09.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_general_display_width_and_height_patch/d2client_set_general_display_width_and_height_patch_1_09.cc
@@ -51,7 +51,7 @@
 namespace sgd2fr::patches::d2client {
 namespace {
 
-__declspec(naked) void __cdecl InterceptionFunc() {
+__declspec(naked) void __cdecl InterceptionFunc01() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -94,21 +94,45 @@ std::vector<mapi::GamePatch>
 SetGeneralDisplayWidthAndHeightPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
-  mapi::GameAddress game_address = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x2380
-  );
-
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          game_address,
+          patch_address_and_size_01.first,
           mapi::BranchType::kCall,
-          &InterceptionFunc,
-          0x23CC - 0x2380
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
       )
   );
 
   return patches;
+}
+
+SetGeneralDisplayWidthAndHeightPatch_1_09D::PatchAddressAndSize
+SetGeneralDisplayWidthAndHeightPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x2380
+          ),
+          0x23CC - 0x2380
+      );
+    }
+
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+        ::mapi::GameAddress::FromOffset(
+            ::d2::DefaultLibrary::kD2Client,
+            0x10DFD
+        ),
+        0x10E49 - 0x10DFD
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_general_display_width_and_height_patch/d2client_set_general_display_width_and_height_patch_1_09.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_general_display_width_and_height_patch/d2client_set_general_display_width_and_height_patch_1_09.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_REQUIRED_D2CLIENT_SET_GENERAL_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2CLIENT_SET_GENERAL_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_REQUIRED_D2CLIENT_SET_GENERAL_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2CLIENT_SET_GENERAL_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,9 +62,16 @@ class SetGeneralDisplayWidthAndHeightPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
 };
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu.cc
@@ -70,6 +70,16 @@ void __cdecl Sgd2fr_D2Client_SetResolutionFromOptionsMenu(
       break;
     }
 
+    case d2::GameVersion::k1_13C: {
+      resolution_settings_address = reinterpret_cast<void*>(
+          mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0xEAAB8
+          ).raw_address()
+      );
+      break;
+    }
+
     default: {
       std::exit(0);
     }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch.cc
@@ -71,6 +71,10 @@ SetResolutionFromOptionsMenuPatch::MakePatch() {
     case d2::GameVersion::k1_09D: {
       return SetResolutionFromOptionsMenuPatch_1_09D();
     }
+
+    case d2::GameVersion::k1_13C: {
+      return SetResolutionFromOptionsMenuPatch_1_13C();
+    }
   }
 }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch.hpp
@@ -50,13 +50,15 @@
 
 #include <sgd2mapi.hpp>
 #include "d2client_set_resolution_from_options_menu_patch_1_09.hpp"
+#include "d2client_set_resolution_from_options_menu_patch_1_13c.hpp"
 
 namespace sgd2fr::patches::d2client {
 
 class SetResolutionFromOptionsMenuPatch {
  public:
   using PatchVariant = std::variant<
-      SetResolutionFromOptionsMenuPatch_1_09D
+      SetResolutionFromOptionsMenuPatch_1_09D,
+      SetResolutionFromOptionsMenuPatch_1_13C
   >;
 
   SetResolutionFromOptionsMenuPatch();

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch_1_09.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch_1_09.cc
@@ -51,7 +51,7 @@
 namespace sgd2fr::patches::d2client {
 namespace {
 
-__declspec(naked) void __cdecl InterceptionFunc() {
+__declspec(naked) void __cdecl InterceptionFunc01() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -96,21 +96,35 @@ std::vector<mapi::GamePatch>
 SetResolutionFromOptionsMenuPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
-  mapi::GameAddress game_address = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x61929
-  );
-
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          game_address,
+          patch_address_and_size_01.first,
           mapi::BranchType::kCall,
-          &InterceptionFunc,
-          0x61933 - 0x61929
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
       )
   );
 
   return patches;
+}
+
+SetResolutionFromOptionsMenuPatch_1_09D::PatchAddressAndSize
+SetResolutionFromOptionsMenuPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x61929
+          ),
+          0x61933 - 0x61929
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch_1_09.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch_1_09.hpp
@@ -60,9 +60,16 @@ class SetResolutionFromOptionsMenuPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
 };
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch_1_13c.cc
@@ -1,0 +1,131 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2client_set_resolution_from_options_menu_patch_1_13c.hpp"
+
+#include "../../../asm_x86_macro.h"
+#include "d2client_set_resolution_from_options_menu.hpp"
+
+namespace sgd2fr::patches::d2client {
+namespace {
+
+__declspec(naked) void __cdecl InterceptionFunc01() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push eax);
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(lea eax, dword ptr [ecx + 0x124])
+  ASM_X86(push eax);
+  ASM_X86(push dword ptr [eax]);
+  ASM_X86(push ecx);
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2Client_SetResolutionFromOptionsMenu));
+  ASM_X86(add esp, 12);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+  ASM_X86(pop eax);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+} // namespace
+
+SetResolutionFromOptionsMenuPatch_1_13C
+::SetResolutionFromOptionsMenuPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void SetResolutionFromOptionsMenuPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void SetResolutionFromOptionsMenuPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+std::vector<mapi::GamePatch>
+SetResolutionFromOptionsMenuPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  return patches;
+}
+
+SetResolutionFromOptionsMenuPatch_1_13C::PatchAddressAndSize
+SetResolutionFromOptionsMenuPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x651E0
+          ),
+          0x651EA - 0x651E0
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch_1_13c.hpp
@@ -1,0 +1,77 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2CLIENT_SET_RESOLUTION_FROM_OPTIONS_MENU_PATCH_D2CLIENT_SET_RESOLUTION_FROM_OPTIONS_MENU_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2CLIENT_SET_RESOLUTION_FROM_OPTIONS_MENU_PATCH_D2CLIENT_SET_RESOLUTION_FROM_OPTIONS_MENU_PATCH_1_13C_HPP_
+
+#include <vector>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr::patches::d2client {
+
+class SetResolutionFromOptionsMenuPatch_1_13C {
+ public:
+  SetResolutionFromOptionsMenuPatch_1_13C();
+
+  void Apply();
+  void Remove();
+
+ private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
+  std::vector<mapi::GamePatch> patches_;
+
+  static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+};
+
+} // namespace sgd2fr::patches::d2client
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2CLIENT_SET_RESOLUTION_FROM_OPTIONS_MENU_PATCH_D2CLIENT_SET_RESOLUTION_FROM_OPTIONS_MENU_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch.cc
@@ -73,6 +73,10 @@ SetResolutionRegistryPatch::MakePatch() {
     case d2::GameVersion::k1_09D: {
       return SetResolutionRegistryPatch_1_09D();
     }
+
+    case d2::GameVersion::k1_13C: {
+      return SetResolutionRegistryPatch_1_13C();
+    }
   }
 }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch.hpp
@@ -50,13 +50,15 @@
 
 #include <sgd2mapi.hpp>
 #include "d2client_set_resolution_registry_patch_1_09d.hpp"
+#include "d2client_set_resolution_registry_patch_1_13c.hpp"
 
 namespace sgd2fr::patches::d2client {
 
 class SetResolutionRegistryPatch {
  public:
   using PatchVariant = std::variant<
-      SetResolutionRegistryPatch_1_09D
+      SetResolutionRegistryPatch_1_09D,
+      SetResolutionRegistryPatch_1_13C
   >;
 
   SetResolutionRegistryPatch();

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_1_09d.cc
@@ -95,33 +95,61 @@ std::vector<mapi::GamePatch>
 SetResolutionRegistryPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
-  mapi::GameAddress game_address_01 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x61059
-  );
-
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          std::move(game_address_01),
+          patch_address_and_size_01.first,
           mapi::BranchType::kCall,
           &InterceptionFunc_01,
-          0x61074 - 0x61059
+          patch_address_and_size_01.second
       )
   );
 
-  mapi::GameAddress game_address_02 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x61075
-  );
-
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
   patches.push_back(
       mapi::GamePatch::MakeGameNopPatch(
-          std::move(game_address_02),
-          0x6107C - 0x61075
+          patch_address_and_size_02.first,
+          patch_address_and_size_02.second
       )
   );
 
   return patches;
+}
+
+SetResolutionRegistryPatch_1_09D::PatchAddressAndSize
+SetResolutionRegistryPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x61059
+          ),
+          0x61074 - 0x61059
+      );
+    }
+  }
+}
+
+SetResolutionRegistryPatch_1_09D::PatchAddressAndSize
+SetResolutionRegistryPatch_1_09D::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x61075
+          ),
+          0x6107C - 0x61075
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_REQUIRED_D2CLIENT_SET_RESOLUTION_REGISTRY_PATCH_D2CLIENT_SET_RESOLUTION_REGISTRY_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_REQUIRED_D2CLIENT_SET_RESOLUTION_REGISTRY_PATCH_D2CLIENT_SET_RESOLUTION_REGISTRY_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,9 +62,17 @@ class SetResolutionRegistryPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
 };
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_1_13c.cc
@@ -1,0 +1,135 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2client_set_resolution_registry_patch_1_13c.hpp"
+
+#include "../../../asm_x86_macro.h"
+#include "d2client_set_resolution_registry.hpp"
+
+namespace sgd2fr::patches::d2client {
+namespace {
+
+__declspec(naked) void __cdecl InterceptionFunc_01() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(sub esp, 4);
+
+  ASM_X86(push eax);
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(lea ecx, dword ptr [ebp - 4]);
+  ASM_X86(push ecx);
+  ASM_X86(push eax);
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2Client_SetResolutionRegistry));
+  ASM_X86(add esp, 8);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+  ASM_X86(pop eax);
+
+  ASM_X86(mov esi, dword ptr [ebp - 4]);
+
+  ASM_X86(add esp, 4);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+} // namespace
+
+SetResolutionRegistryPatch_1_13C::SetResolutionRegistryPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void SetResolutionRegistryPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void SetResolutionRegistryPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+std::vector<mapi::GamePatch>
+SetResolutionRegistryPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc_01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  return patches;
+}
+
+SetResolutionRegistryPatch_1_13C::PatchAddressAndSize
+SetResolutionRegistryPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x662AA
+          ),
+          0x662CC - 0x662AA
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_1_13c.hpp
@@ -1,0 +1,79 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2CLIENT_SET_RESOLUTION_REGISTRY_PATCH_D2CLIENT_SET_RESOLUTION_REGISTRY_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2CLIENT_SET_RESOLUTION_REGISTRY_PATCH_D2CLIENT_SET_RESOLUTION_REGISTRY_PATCH_1_13C_HPP_
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr::patches::d2client {
+
+class SetResolutionRegistryPatch_1_13C {
+ public:
+  SetResolutionRegistryPatch_1_13C();
+
+  void Apply();
+  void Remove();
+
+ private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
+  std::vector<mapi::GamePatch> patches_;
+
+  static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+};
+
+} // namespace sgd2fr::patches::d2client
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2CLIENT_SET_RESOLUTION_REGISTRY_PATCH_D2CLIENT_SET_RESOLUTION_REGISTRY_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_screen_shift_patch/d2client_set_screen_shift_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_screen_shift_patch/d2client_set_screen_shift_patch.cc
@@ -68,7 +68,8 @@ SetScreenShiftPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_09D:
+    case ::d2::GameVersion::k1_13C: {
       return SetScreenShiftPatch_1_09D();
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_screen_shift_patch/d2client_set_screen_shift_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_screen_shift_patch/d2client_set_screen_shift_patch_1_09d.cc
@@ -51,7 +51,7 @@
 namespace sgd2fr::patches::d2client {
 namespace {
 
-__declspec(naked) void __cdecl InterceptionFunc() {
+__declspec(naked) void __cdecl InterceptionFunc01() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -91,21 +91,45 @@ std::vector<mapi::GamePatch>
 SetScreenShiftPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
-  mapi::GameAddress game_address = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x865BF
-  );
-
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          game_address,
+          patch_address_and_size_01.first,
           mapi::BranchType::kCall,
-          &InterceptionFunc,
-          0x865E6 - 0x865BF
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
       )
   );
 
   return patches;
+}
+
+SetScreenShiftPatch_1_09D::PatchAddressAndSize
+SetScreenShiftPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x865BF
+          ),
+          0x865E6 - 0x865BF
+      );
+    }
+
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+        ::mapi::GameAddress::FromOffset(
+            ::d2::DefaultLibrary::kD2Client,
+            0xC39F6
+        ),
+        0xC3A1D - 0xC39F6
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_screen_shift_patch/d2client_set_screen_shift_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_screen_shift_patch/d2client_set_screen_shift_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_REQUIRED_D2CLIENT_SET_SCREEN_SHIFT_PATCH_D2CLIENT_SET_SCREEN_SHIFT_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_REQUIRED_D2CLIENT_SET_SCREEN_SHIFT_PATCH_D2CLIENT_SET_SCREEN_SHIFT_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,9 +62,16 @@ class SetScreenShiftPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
 };
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch.cc
@@ -71,6 +71,10 @@ UnloadCelFileCollectionPatch::MakePatch() {
     case d2::GameVersion::k1_09D: {
       return UnloadCelFileCollectionPatch_1_09D();
     }
+
+    case d2::GameVersion::k1_13C: {
+      return UnloadCelFileCollectionPatch_1_13C();
+    }
   }
 }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch.hpp
@@ -50,13 +50,15 @@
 
 #include <sgd2mapi.hpp>
 #include "d2client_unload_cel_file_collection_patch_1_09d.hpp"
+#include "d2client_unload_cel_file_collection_patch_1_13c.hpp"
 
 namespace sgd2fr::patches::d2client {
 
 class UnloadCelFileCollectionPatch {
  public:
   using PatchVariant = std::variant<
-      UnloadCelFileCollectionPatch_1_09D
+      UnloadCelFileCollectionPatch_1_09D,
+      UnloadCelFileCollectionPatch_1_13C
   >;
 
   UnloadCelFileCollectionPatch();

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch_1_09d.cc
@@ -91,21 +91,35 @@ std::vector<mapi::GamePatch>
 UnloadCelFileCollectionPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
-  mapi::GameAddress game_address_01 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Client,
-      0x57FB9
-  );
-
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          std::move(game_address_01),
+          patch_address_and_size_01.first,
           mapi::BranchType::kJump,
           &InterceptionFunc_01,
-          5
+          patch_address_and_size_01.second
       )
   );
 
   return patches;
+}
+
+UnloadCelFileCollectionPatch_1_09D::PatchAddressAndSize
+UnloadCelFileCollectionPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x57FB9
+          ),
+          5
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_REQUIRED_D2CLIENT_UNLOAD_CEL_FILE_COLLECTION_PATCH_D2CLIENT_UNLOAD_CEL_FILE_COLLECTION_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_REQUIRED_D2CLIENT_UNLOAD_CEL_FILE_COLLECTION_PATCH_D2CLIENT_UNLOAD_CEL_FILE_COLLECTION_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,9 +62,16 @@ class UnloadCelFileCollectionPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
 };
 
 } // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch_1_13c.cc
@@ -1,0 +1,130 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2client_unload_cel_file_collection_patch_1_13c.hpp"
+
+#include "../../../asm_x86_macro.h"
+#include "d2client_unload_cel_file_collection.hpp"
+
+namespace sgd2fr::patches::d2client {
+namespace {
+
+__declspec(naked) void __cdecl InterceptionFunc_01() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push eax);
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2Client_UnloadCelFileCollection));
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+  ASM_X86(pop eax);
+
+  ASM_X86(leave);
+
+  // Original code
+  ASM_X86(pop edi);
+  ASM_X86(pop esi);
+
+  ASM_X86(ret);
+}
+
+} // namespace
+
+UnloadCelFileCollectionPatch_1_13C::UnloadCelFileCollectionPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void UnloadCelFileCollectionPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void UnloadCelFileCollectionPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+std::vector<mapi::GamePatch>
+UnloadCelFileCollectionPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          mapi::BranchType::kJump,
+          &InterceptionFunc_01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  return patches;
+}
+
+UnloadCelFileCollectionPatch_1_13C::PatchAddressAndSize
+UnloadCelFileCollectionPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Client,
+              0x26F9B
+          ),
+          5
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2client

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch_1_13c.hpp
@@ -1,0 +1,79 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2CLIENT_UNLOAD_CEL_FILE_COLLECTION_PATCH_D2CLIENT_UNLOAD_CEL_FILE_COLLECTION_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2CLIENT_UNLOAD_CEL_FILE_COLLECTION_PATCH_D2CLIENT_UNLOAD_CEL_FILE_COLLECTION_PATCH_1_13C_HPP_
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr::patches::d2client {
+
+class UnloadCelFileCollectionPatch_1_13C {
+ public:
+  UnloadCelFileCollectionPatch_1_13C();
+
+  void Apply();
+  void Remove();
+
+ private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
+  std::vector<mapi::GamePatch> patches_;
+
+  static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+};
+
+} // namespace sgd2fr::patches::d2client
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2CLIENT_UNLOAD_CEL_FILE_COLLECTION_PATCH_D2CLIENT_UNLOAD_CEL_FILE_COLLECTION_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch.cc
@@ -80,6 +80,10 @@ SetBitBlockWidthAndHeightPatch::MakePatch() {
     case d2::GameVersion::k1_09D: {
       return SetBitBlockWidthAndHeightPatch_1_09D();
     }
+
+    case d2::GameVersion::k1_13C: {
+      return SetBitBlockWidthAndHeightPatch_1_13C();
+    }
   }
 }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch.hpp
@@ -51,13 +51,15 @@
 
 #include <sgd2mapi.hpp>
 #include "d2ddraw_set_bit_block_width_and_height_patch_1_09d.hpp"
+#include "d2ddraw_set_bit_block_width_and_height_patch_1_13c.hpp"
 
 namespace sgd2fr::patches::d2ddraw {
 
 class SetBitBlockWidthAndHeightPatch {
  public:
   using PatchVariant = std::variant<
-      SetBitBlockWidthAndHeightPatch_1_09D
+      SetBitBlockWidthAndHeightPatch_1_09D,
+      SetBitBlockWidthAndHeightPatch_1_13C
   >;
 
   using PatchType = std::optional<PatchVariant>;

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_09d.cc
@@ -94,33 +94,61 @@ std::vector<mapi::GamePatch>
 SetBitBlockWidthAndHeightPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
-  mapi::GameAddress game_address_01 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2DDraw,
-      0x17DF
-  );
-
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          std::move(game_address_01),
+          patch_address_and_size_01.first,
           mapi::BranchType::kCall,
           &InterceptionFunc_01,
-          0x1803 - 0x17DF
+          patch_address_and_size_01.second
       )
   );
 
-  mapi::GameAddress game_address_02 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2DDraw,
-      0x180A
-  );
-
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
   patches.push_back(
       mapi::GamePatch::MakeGameNopPatch(
-          std::move(game_address_02),
-          0x1810 - 0x180A
+          patch_address_and_size_02.first,
+          patch_address_and_size_02.second
       )
   );
 
   return patches;
+}
+
+SetBitBlockWidthAndHeightPatch_1_09D::PatchAddressAndSize
+SetBitBlockWidthAndHeightPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x17DF
+          ),
+          0x1803 - 0x17DF
+      );
+    }
+  }
+}
+
+SetBitBlockWidthAndHeightPatch_1_09D::PatchAddressAndSize
+SetBitBlockWidthAndHeightPatch_1_09D::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x180A
+          ),
+          0x1810 - 0x180A
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2ddraw

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_REQUIRED_D2DDRAW_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_D2DDRAW_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_REQUIRED_D2DDRAW_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_D2DDRAW_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,9 +62,17 @@ class SetBitBlockWidthAndHeightPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
 };
 
 } // namespace sgd2fr::patches::d2ddraw

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_13c.cc
@@ -1,0 +1,138 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2ddraw_set_bit_block_width_and_height_patch_1_13c.hpp"
+
+#include "../../../asm_x86_macro.h"
+#include "d2ddraw_set_bit_block_width_and_height.hpp"
+
+namespace sgd2fr::patches::d2ddraw {
+namespace {
+
+__declspec(naked) void __cdecl InterceptionFunc_01() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(sub esp, 8);
+
+  ASM_X86(push eax);
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(lea edx, dword ptr [ebp - 8]);
+  ASM_X86(push edx);
+  ASM_X86(lea ecx, dword ptr [ebp - 4]);
+  ASM_X86(push ecx);
+  ASM_X86(push eax);
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2DDraw_SetBitBlockWidthAndHeight));
+  ASM_X86(add esp, 12);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+  ASM_X86(pop eax);
+
+  ASM_X86(mov ecx, dword ptr [ebp - 4]);
+  ASM_X86(mov edx, dword ptr [ebp - 8]);
+
+  ASM_X86(add esp, 8);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+} // namespace
+
+SetBitBlockWidthAndHeightPatch_1_13C::SetBitBlockWidthAndHeightPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void SetBitBlockWidthAndHeightPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void SetBitBlockWidthAndHeightPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+std::vector<mapi::GamePatch>
+SetBitBlockWidthAndHeightPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc_01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  return patches;
+}
+
+SetBitBlockWidthAndHeightPatch_1_13C::PatchAddressAndSize
+SetBitBlockWidthAndHeightPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x85C2
+          ),
+          0x85E6 - 0x85C2
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2ddraw

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_13c.hpp
@@ -1,0 +1,79 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2DDRAW_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_D2DDRAW_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2DDRAW_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_D2DDRAW_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr::patches::d2ddraw {
+
+class SetBitBlockWidthAndHeightPatch_1_13C {
+ public:
+  SetBitBlockWidthAndHeightPatch_1_13C();
+
+  void Apply();
+  void Remove();
+
+ private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
+  std::vector<mapi::GamePatch> patches_;
+
+  static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+};
+
+} // namespace sgd2fr::patches::d2ddraw
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2DDRAW_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_D2DDRAW_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_cel_display_left_and_right_patch/d2ddraw_set_cel_display_left_and_right_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_cel_display_left_and_right_patch/d2ddraw_set_cel_display_left_and_right_patch_1_09d.cc
@@ -93,21 +93,45 @@ std::vector<mapi::GamePatch>
 SetCelDisplayLeftAndRightPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
-  mapi::GameAddress game_address = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2DDraw,
-      0x4430
-  );
-
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          std::move(game_address),
+          patch_address_and_size_01.first,
           mapi::BranchType::kJump,
           &InterceptionFunc,
-          0x4450 - 0x4430
+          patch_address_and_size_01.second
       )
   );
 
   return patches;
+}
+
+SetCelDisplayLeftAndRightPatch_1_09D::PatchAddressAndSize
+SetCelDisplayLeftAndRightPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x4430
+          ),
+          0x4450 - 0x4430
+      );
+    }
+
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x69F0
+          ),
+          0x6A10 - 0x69F0
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2ddraw

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_cel_display_left_and_right_patch/d2ddraw_set_cel_display_left_and_right_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_cel_display_left_and_right_patch/d2ddraw_set_cel_display_left_and_right_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_REQUIRED_D2DDRAW_SET_CEL_DISPLAY_LEFT_AND_RIGHT_PATCH_D2DDRAW_SET_CEL_DISPLAY_LEFT_AND_RIGHT_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_REQUIRED_D2DDRAW_SET_CEL_DISPLAY_LEFT_AND_RIGHT_PATCH_D2DDRAW_SET_CEL_DISPLAY_LEFT_AND_RIGHT_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,9 +62,16 @@ class SetCelDisplayLeftAndRightPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
 };
 
 } // namespace sgd2fr::patches::d2ddraw

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch.cc
@@ -80,6 +80,10 @@ SetDisplayWidthAndHeightPatch::MakePatch() {
     case d2::GameVersion::k1_09D: {
       return SetDisplayWidthAndHeightPatch_1_09D();
     }
+
+    case d2::GameVersion::k1_13C: {
+      return SetDisplayWidthAndHeightPatch_1_13C();
+    }
   }
 }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch.hpp
@@ -51,13 +51,15 @@
 
 #include <sgd2mapi.hpp>
 #include "d2ddraw_set_display_width_and_height_patch_1_09d.hpp"
+#include "d2ddraw_set_display_width_and_height_patch_1_13c.hpp"
 
 namespace sgd2fr::patches::d2ddraw {
 
 class SetDisplayWidthAndHeightPatch {
  public:
   using PatchVariant = std::variant<
-      SetDisplayWidthAndHeightPatch_1_09D
+      SetDisplayWidthAndHeightPatch_1_09D,
+      SetDisplayWidthAndHeightPatch_1_13C
   >;
 
   using PatchType = std::optional<PatchVariant>;

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_09d.cc
@@ -94,33 +94,61 @@ std::vector<mapi::GamePatch>
 SetDisplayWidthAndHeightPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
-  mapi::GameAddress game_address_01 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2DDraw,
-      0x181F
-  );
-
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          std::move(game_address_01),
+          patch_address_and_size_01.first,
           mapi::BranchType::kCall,
           &InterceptionFunc_01,
-          0x1832 - 0x181F
+          patch_address_and_size_01.second
       )
   );
 
-  mapi::GameAddress game_address_02 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2DDraw,
-      0x1837
-  );
-
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
   patches.push_back(
       mapi::GamePatch::MakeGameNopPatch(
-          std::move(game_address_02),
-          0x183D - 0x1837
+          patch_address_and_size_02.first,
+          patch_address_and_size_02.second
       )
   );
 
   return patches;
+}
+
+SetDisplayWidthAndHeightPatch_1_09D::PatchAddressAndSize
+SetDisplayWidthAndHeightPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x181F
+          ),
+          0x1832 - 0x181F
+      );
+    }
+  }
+}
+
+SetDisplayWidthAndHeightPatch_1_09D::PatchAddressAndSize
+SetDisplayWidthAndHeightPatch_1_09D::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x1837
+          ),
+          0x183D - 0x1837
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2ddraw

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_REQUIRED_D2DDRAW_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2DDRAW_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_REQUIRED_D2DDRAW_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2DDRAW_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,9 +62,17 @@ class SetDisplayWidthAndHeightPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
 };
 
 } // namespace sgd2fr::patches::d2ddraw

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_13c.cc
@@ -1,0 +1,164 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2ddraw_set_display_width_and_height_patch_1_13c.hpp"
+
+#include "../../../asm_x86_macro.h"
+#include "d2ddraw_set_display_width_and_height.hpp"
+
+namespace sgd2fr::patches::d2ddraw {
+namespace {
+
+__declspec(naked) void __cdecl InterceptionFunc_01() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(sub esp, 8);
+
+  ASM_X86(push eax);
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(lea edx, dword ptr [ebp - 8]);
+  ASM_X86(push edx);
+  ASM_X86(lea ecx, dword ptr [ebp - 4]);
+  ASM_X86(push ecx);
+  ASM_X86(push eax);
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2DDraw_SetDisplayWidthAndHeight));
+  ASM_X86(add esp, 12);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+  ASM_X86(pop eax);
+
+  ASM_X86(mov ecx, dword ptr [ebp - 4]);
+  ASM_X86(mov edx, dword ptr [ebp - 8]);
+
+  ASM_X86(add esp, 8);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+} // namespace
+
+SetDisplayWidthAndHeightPatch_1_13C::SetDisplayWidthAndHeightPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void SetDisplayWidthAndHeightPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void SetDisplayWidthAndHeightPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+std::vector<mapi::GamePatch>
+SetDisplayWidthAndHeightPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc_01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
+  patches.push_back(
+      mapi::GamePatch::MakeGameNopPatch(
+          patch_address_and_size_02.first,
+          patch_address_and_size_02.second
+      )
+  );
+
+  return patches;
+}
+
+SetDisplayWidthAndHeightPatch_1_13C::PatchAddressAndSize
+SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x85E6
+          ),
+          0x85ED - 0x85E6
+      );
+    }
+  }
+}
+
+SetDisplayWidthAndHeightPatch_1_13C::PatchAddressAndSize
+SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x85F9
+          ),
+          0x8600 - 0x85F9
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2ddraw

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_13c.hpp
@@ -1,0 +1,80 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2DDRAW_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2DDRAW_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2DDRAW_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2DDRAW_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr::patches::d2ddraw {
+
+class SetDisplayWidthAndHeightPatch_1_13C {
+ public:
+  SetDisplayWidthAndHeightPatch_1_13C();
+
+  void Apply();
+  void Remove();
+
+ private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
+  std::vector<mapi::GamePatch> patches_;
+
+  static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
+};
+
+} // namespace sgd2fr::patches::d2ddraw
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2DDRAW_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2DDRAW_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch.cc
@@ -80,6 +80,10 @@ SetDisplayWidthAndHeightPatch::MakePatch() {
     case d2::GameVersion::k1_09D: {
       return SetDisplayWidthAndHeightPatch_1_09D();
     }
+
+    case d2::GameVersion::k1_13C: {
+      return SetDisplayWidthAndHeightPatch_1_13C();
+    }
   }
 }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch.hpp
@@ -52,13 +52,15 @@
 
 #include <sgd2mapi.hpp>
 #include "d2direct3d_set_display_width_and_height_patch_1_09d.hpp"
+#include "d2direct3d_set_display_width_and_height_patch_1_13c.hpp"
 
 namespace sgd2fr::patches::d2direct3d {
 
 class SetDisplayWidthAndHeightPatch {
  public:
   using PatchVariant = std::variant<
-      SetDisplayWidthAndHeightPatch_1_09D
+      SetDisplayWidthAndHeightPatch_1_09D,
+      SetDisplayWidthAndHeightPatch_1_13C
   >;
 
   using PatchType = std::optional<PatchVariant>;

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_REQUIRED_D2DIRECT3D_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2DIRECT3D_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_REQUIRED_D2DIRECT3D_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2DIRECT3D_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,9 +62,17 @@ class SetDisplayWidthAndHeightPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
 };
 
 } // namespace sgd2fr::patches::d2direct3d

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_13c.cc
@@ -1,0 +1,165 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2direct3d_set_display_width_and_height_patch_1_13c.hpp"
+
+#include <array>
+
+#include "../../../asm_x86_macro.h"
+#include "d2direct3d_set_display_width_and_height.hpp"
+
+namespace sgd2fr::patches::d2direct3d {
+namespace {
+
+__declspec(naked) void __cdecl InterceptionFunc01() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+  
+  ASM_X86(push eax);
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(push eax);
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2Direct3D_SetDisplayWidthAndHeight));
+  ASM_X86(add esp, 4);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+  ASM_X86(pop eax);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+/**
+ * cmp eax, 1
+ * je
+ */
+constexpr std::array<std::uint8_t, 4> kPatchBuffer02 = {
+    0x83, 0xF8, 0x01, 0x74
+};
+
+} // namespace
+
+SetDisplayWidthAndHeightPatch_1_13C::SetDisplayWidthAndHeightPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void SetDisplayWidthAndHeightPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void SetDisplayWidthAndHeightPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+std::vector<mapi::GamePatch>
+SetDisplayWidthAndHeightPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBufferPatch(
+          patch_address_and_size_02.first,
+          kPatchBuffer02.data(),
+          patch_address_and_size_02.second
+      )
+  );
+
+  return patches;
+}
+
+SetDisplayWidthAndHeightPatch_1_13C::PatchAddressAndSize
+SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0xB9A4
+          ),
+          (0xB9DE - kPatchBuffer02.size()) - 0xB9A4
+      );
+    }
+  }
+}
+
+SetDisplayWidthAndHeightPatch_1_13C::PatchAddressAndSize
+SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0xB9DE - kPatchBuffer02.size()
+          ),
+          kPatchBuffer02.size()
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2direct3d

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_13c.hpp
@@ -1,0 +1,80 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2DIRECT3D_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2DIRECT3D_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2DIRECT3D_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2DIRECT3D_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr::patches::d2direct3d {
+
+class SetDisplayWidthAndHeightPatch_1_13C {
+ public:
+  SetDisplayWidthAndHeightPatch_1_13C();
+
+  void Apply();
+  void Remove();
+
+ private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
+  std::vector<mapi::GamePatch> patches_;
+
+  static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
+};
+
+} // namespace sgd2fr::patches::d2direct3d
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2DIRECT3D_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2DIRECT3D_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height.cc
@@ -51,11 +51,28 @@
 
 namespace sgd2fr::patches {
 
-void __cdecl Sgd2fr_D2GDI_SetBitBlockWidthAndHeight(std::size_t resolution_mode) {
-  std::tuple<int, int> resolution = GetIngameResolutionFromId(resolution_mode);
+void __cdecl Sgd2fr_D2GDI_GetBitBlockWidthAndHeight(
+    ::std::size_t resolution_mode,
+    ::std::int32_t* width,
+    ::std::int32_t* height
+) {
+  ::std::tuple<int, int> resolution = GetIngameResolutionFromId(
+      resolution_mode
+  );
 
-  int bit_block_width = std::get<0>(resolution);
-  int bit_block_height = std::get<1>(resolution);
+  *width = ::std::get<0>(resolution);
+  *height = ::std::get<1>(resolution);
+}
+
+void __cdecl Sgd2fr_D2GDI_SetBitBlockWidthAndHeight(
+    ::std::size_t resolution_mode
+) {
+  ::std::tuple<int, int> resolution = GetIngameResolutionFromId(
+      resolution_mode
+  );
+
+  int bit_block_width = ::std::get<0>(resolution);
+  int bit_block_height = ::std::get<1>(resolution);
 
   d2::d2gdi::SetBitBlockWidth(bit_block_width);
   d2::d2gdi::SetBitBlockHeight(bit_block_height);

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height.hpp
@@ -47,10 +47,19 @@
 #define SGD2FR_PATCHES_REQUIRED_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_HPP_
 
 #include <cstddef>
+#include <cstdint>
 
 namespace sgd2fr::patches {
 
-extern "C" void __cdecl Sgd2fr_D2GDI_SetBitBlockWidthAndHeight(std::size_t resolution_mode);
+extern "C" void __cdecl Sgd2fr_D2GDI_GetBitBlockWidthAndHeight(
+    ::std::size_t resolution_mode,
+    ::std::int32_t* width,
+    ::std::int32_t* height
+);
+
+extern "C" void __cdecl Sgd2fr_D2GDI_SetBitBlockWidthAndHeight(
+    ::std::size_t resolution_mode
+);
 
 } // namespace sgd2fr::patches
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch.cc
@@ -80,6 +80,10 @@ SetBitBlockWidthAndHeightPatch::MakePatch() {
     case d2::GameVersion::k1_09D: {
       return SetBitBlockWidthAndHeightPatch_1_09D();
     }
+
+    case d2::GameVersion::k1_13C: {
+      return SetBitBlockWidthAndHeightPatch_1_13C();
+    }
   }
 }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch.hpp
@@ -51,13 +51,15 @@
 
 #include <sgd2mapi.hpp>
 #include "d2gdi_set_bit_block_width_and_height_patch_1_09d.hpp"
+#include "d2gdi_set_bit_block_width_and_height_patch_1_13c.hpp"
 
 namespace sgd2fr::patches::d2gdi {
 
 class SetBitBlockWidthAndHeightPatch {
  public:
   using PatchVariant = std::variant<
-      SetBitBlockWidthAndHeightPatch_1_09D
+      SetBitBlockWidthAndHeightPatch_1_09D,
+      SetBitBlockWidthAndHeightPatch_1_13C
   >;
 
   using PatchType = std::optional<PatchVariant>;

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_REQUIRED_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_REQUIRED_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,9 +62,16 @@ class SetBitBlockWidthAndHeightPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
 };
 
 } // namespace sgd2fr::patches::d2gdi

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_1_13c.cc
@@ -1,0 +1,137 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2gdi_set_bit_block_width_and_height_patch_1_13c.hpp"
+
+#include "../../../asm_x86_macro.h"
+#include "d2gdi_set_bit_block_width_and_height.hpp"
+
+namespace sgd2fr::patches::d2gdi {
+namespace {
+
+__declspec(naked) void __cdecl InterceptionFunc01() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(sub esp, 8);
+  ASM_X86(lea esi, dword ptr [ebp - 4]);
+  ASM_X86(lea edx, dword ptr [ebp - 8]);
+
+  ASM_X86(push eax);
+  ASM_X86(push ecx);
+
+  ASM_X86(push edx);
+  ASM_X86(push esi);
+  ASM_X86(push eax);
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2GDI_GetBitBlockWidthAndHeight));
+  ASM_X86(add esp, 12);
+
+  ASM_X86(pop ecx);
+  ASM_X86(pop eax);
+
+  // Original code
+  ASM_X86(mov esi, dword ptr [ebp - 4]);
+  ASM_X86(mov edx, dword ptr [ebp - 8]);
+
+  ASM_X86(add esp, 8);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+} // namespace
+
+SetBitBlockWidthAndHeightPatch_1_13C::SetBitBlockWidthAndHeightPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void SetBitBlockWidthAndHeightPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void SetBitBlockWidthAndHeightPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+std::vector<mapi::GamePatch>
+SetBitBlockWidthAndHeightPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  return patches;
+}
+
+SetBitBlockWidthAndHeightPatch_1_13C::PatchAddressAndSize
+SetBitBlockWidthAndHeightPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+        ::mapi::GameAddress::FromOffset(
+            ::d2::DefaultLibrary::kD2GDI,
+            0x6D34
+        ),
+        0x6D5F - 0x6D34
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2gdi

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_1_13c.hpp
@@ -1,0 +1,79 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr::patches::d2gdi {
+
+class SetBitBlockWidthAndHeightPatch_1_13C {
+ public:
+  SetBitBlockWidthAndHeightPatch_1_13C();
+
+  void Apply();
+  void Remove();
+
+ private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
+  std::vector<mapi::GamePatch> patches_;
+
+  static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+};
+
+} // namespace sgd2fr::patches::d2gdi
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch.cc
@@ -77,8 +77,12 @@ SetCelDisplayLeftAndRightPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_09D: {
       return SetCelDisplayLeftAndRightPatch_1_09D();
+    }
+
+    case ::d2::GameVersion::k1_13C: {
+      return SetCelDisplayLeftAndRightPatch_1_13C();
     }
   }
 }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch.hpp
@@ -51,13 +51,15 @@
 
 #include <sgd2mapi.hpp>
 #include "d2gdi_set_cel_display_left_and_right_patch_1_09d.hpp"
+#include "d2gdi_set_cel_display_left_and_right_patch_1_13c.hpp"
 
 namespace sgd2fr::patches::d2gdi {
 
 class SetCelDisplayLeftAndRightPatch {
  public:
   using PatchVariant = std::variant<
-      SetCelDisplayLeftAndRightPatch_1_09D
+      SetCelDisplayLeftAndRightPatch_1_09D,
+      SetCelDisplayLeftAndRightPatch_1_13C
   >;
 
   using PatchType = std::optional<PatchVariant>;
@@ -72,8 +74,6 @@ class SetCelDisplayLeftAndRightPatch {
 
   static PatchType MakePatch();
 };
-
-std::vector<mapi::GamePatch> MakeSetD2GDICelDisplayLeftAndRightPatch();
 
 } // namespace sgd2fr::patches::d2gdi
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_09d.cc
@@ -51,7 +51,7 @@
 namespace sgd2fr::patches::d2gdi {
 namespace {
 
-__declspec(naked) void __cdecl InterceptionFunc() {
+__declspec(naked) void __cdecl InterceptionFunc01() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -93,21 +93,36 @@ std::vector<mapi::GamePatch>
 SetCelDisplayLeftAndRightPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
-  mapi::GameAddress game_address = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2GDI,
-      0x25A0
-  );
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
 
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          game_address,
+          patch_address_and_size_01.first,
           mapi::BranchType::kCall,
-          &InterceptionFunc,
-          0x25D5 - 0x25A0
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
       )
   );
 
   return patches;
+}
+
+SetCelDisplayLeftAndRightPatch_1_09D::PatchAddressAndSize
+SetCelDisplayLeftAndRightPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x25A0
+          ),
+          0x25D5 - 0x25A0
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2gdi

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_REQUIRED_D2GDI_SET_CEL_DISPLAY_LEFT_AND_RIGHT_PATCH_D2GDI_SET_CEL_DISPLAY_LEFT_AND_RIGHT_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_REQUIRED_D2GDI_SET_CEL_DISPLAY_LEFT_AND_RIGHT_PATCH_D2GDI_SET_CEL_DISPLAY_LEFT_AND_RIGHT_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,9 +62,16 @@ class SetCelDisplayLeftAndRightPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
 };
 
 } // namespace sgd2fr::patches::d2gdi

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_13c.cc
@@ -1,0 +1,133 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2gdi_set_cel_display_left_and_right_patch_1_13c.hpp"
+
+#include "../../../asm_x86_macro.h"
+#include "d2gdi_set_cel_display_left_and_right.hpp"
+
+namespace sgd2fr::patches::d2gdi {
+namespace {
+
+__declspec(naked) void __cdecl InterceptionFunc01_1_13C() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push eax);
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(push esi);
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2GDI_SetCelDisplayLeftAndRight));
+  ASM_X86(add esp, 4);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+  ASM_X86(pop eax);
+
+  ASM_X86(leave);
+
+  // Original code
+  ASM_X86(pop edi);
+  ASM_X86(pop esi);
+
+  ASM_X86(ret);
+}
+
+} // namespace
+
+SetCelDisplayLeftAndRightPatch_1_13C::SetCelDisplayLeftAndRightPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void SetCelDisplayLeftAndRightPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void SetCelDisplayLeftAndRightPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+std::vector<mapi::GamePatch>
+SetCelDisplayLeftAndRightPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          mapi::BranchType::kJump,
+          &InterceptionFunc01_1_13C,
+          patch_address_and_size_01.second
+      )
+  );
+
+  return patches;
+}
+
+SetCelDisplayLeftAndRightPatch_1_13C::PatchAddressAndSize
+SetCelDisplayLeftAndRightPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+        ::mapi::GameAddress::FromOffset(
+            ::d2::DefaultLibrary::kD2GDI,
+            0x7049
+        ),
+        0x7077 - 0x7049
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2gdi

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_13c.hpp
@@ -1,0 +1,79 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2GDI_SET_CEL_DISPLAY_LEFT_AND_RIGHT_PATCH_D2GDI_SET_CEL_DISPLAY_LEFT_AND_RIGHT_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2GDI_SET_CEL_DISPLAY_LEFT_AND_RIGHT_PATCH_D2GDI_SET_CEL_DISPLAY_LEFT_AND_RIGHT_PATCH_1_13C_HPP_
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr::patches::d2gdi {
+
+class SetCelDisplayLeftAndRightPatch_1_13C {
+ public:
+  SetCelDisplayLeftAndRightPatch_1_13C();
+
+  void Apply();
+  void Remove();
+
+ private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
+  std::vector<mapi::GamePatch> patches_;
+
+  static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+};
+
+} // namespace sgd2fr::patches::d2gdi
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2GDI_SET_CEL_DISPLAY_LEFT_AND_RIGHT_PATCH_D2GDI_SET_CEL_DISPLAY_LEFT_AND_RIGHT_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window.cc
@@ -61,15 +61,10 @@ int __cdecl Sgd2fr_D2GFX_IsNeedResizeWindowPatch() {
       &client_rect
   );
 
+  // Original code does not exit on error, but effectively returns true
+  // on the windows resolution check.
   if (!is_get_client_rect_success) {
-    ::mdc::error::ExitOnWindowsFunctionError(
-        __FILEW__,
-        __LINE__,
-        L"GetClientRect",
-        GetLastError()
-    );
-
-    return false;
+    return true;
   }
 
   ::std::tuple ingame_resolution = GetVideoModeDisplayResolution();

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window.cc
@@ -1,0 +1,84 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2gfx_is_need_resize_window.hpp"
+
+#include <mdc/error/exit_on_error.hpp>
+#include <mdc/wchar_t/filew.h>
+#include <sgd2mapi.hpp>
+
+#include "../../../helper/game_resolution.hpp"
+
+namespace sgd2fr::patches {
+
+int __cdecl Sgd2fr_D2GFX_IsNeedResizeWindowPatch() {
+  RECT client_rect = { 0 };
+
+  BOOL is_get_client_rect_success = GetClientRect(
+      ::d2::d2gfx::GetWindowHandle(),
+      &client_rect
+  );
+
+  if (!is_get_client_rect_success) {
+    ::mdc::error::ExitOnWindowsFunctionError(
+        __FILEW__,
+        __LINE__,
+        L"GetClientRect",
+        GetLastError()
+    );
+
+    return false;
+  }
+
+  ::std::tuple ingame_resolution = GetVideoModeDisplayResolution();
+
+  int client_width = client_rect.right - client_rect.left;
+  int client_height = client_rect.bottom - client_rect.top;
+
+  return (client_width <= ::std::get<0>(ingame_resolution)
+      && client_height <= ::std::get<1>(ingame_resolution));
+}
+
+} // namespace sgd2fr::patches

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window.hpp
@@ -1,0 +1,59 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESIZE_WINDOW_PATCH_D2GFX_IS_NEED_RESIZE_WINDOW_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESIZE_WINDOW_PATCH_D2GFX_IS_NEED_RESIZE_WINDOW_HPP_
+
+#include <windows.h>
+
+#include <cstdint>
+
+namespace sgd2fr::patches {
+
+extern "C" int __cdecl Sgd2fr_D2GFX_IsNeedResizeWindowPatch();
+
+} // namespace sgd2fr::patches
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESIZE_WINDOW_PATCH_D2GFX_IS_NEED_RESIZE_WINDOW_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window_patch.cc
@@ -1,0 +1,85 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2gfx_is_need_resize_window_patch.hpp"
+
+namespace sgd2fr::patches::d2gfx {
+
+IsNeedResizeWindowPatch::IsNeedResizeWindowPatch()
+  : patch_(MakePatch()) {
+}
+
+void IsNeedResizeWindowPatch::Apply() {
+  if (this->patch_.has_value()) {
+    std::visit([](auto& patch) {
+      patch.Apply();
+    }, this->patch_.value());
+  }
+}
+
+void IsNeedResizeWindowPatch::Remove() {
+  if (this->patch_.has_value()) {
+    std::visit([](auto& patch) {
+      patch.Remove();
+    }, this->patch_.value());
+  }
+}
+
+IsNeedResizeWindowPatch::PatchType
+IsNeedResizeWindowPatch::MakePatch() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  if (running_game_version < ::d2::GameVersion::k1_13C) {
+    return ::std::nullopt;
+  }
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return IsNeedResizeWindowPatch_1_13C();
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2gfx

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window_patch.hpp
@@ -1,0 +1,78 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESIZE_WINDOW_PATCH_D2GFX_IS_NEED_RESIZE_WINDOW_PATCH_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESIZE_WINDOW_PATCH_D2GFX_IS_NEED_RESIZE_WINDOW_PATCH_HPP_
+
+#include <optional>
+#include <variant>
+
+#include <sgd2mapi.hpp>
+#include "d2gfx_is_need_resize_window_patch_1_13c.hpp"
+
+namespace sgd2fr::patches::d2gfx {
+
+class IsNeedResizeWindowPatch {
+ public:
+  using PatchVariant = std::variant<
+      IsNeedResizeWindowPatch_1_13C
+  >;
+
+  using PatchType = ::std::optional<PatchVariant>;
+
+  IsNeedResizeWindowPatch();
+
+  void Apply();
+  void Remove();
+
+ private:
+  PatchType patch_;
+
+  static PatchType MakePatch();
+};
+
+} // namespace sgd2fr::patches::d2gfx
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESIZE_WINDOW_PATCH_D2GFX_IS_NEED_RESIZE_WINDOW_PATCH_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window_patch_1_13c.cc
@@ -1,0 +1,160 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2gfx_is_need_resize_window_patch_1_13c.hpp"
+
+#include <array>
+
+#include "../../../asm_x86_macro.h"
+#include "d2gfx_is_need_resize_window.hpp"
+
+namespace sgd2fr::patches::d2gfx {
+namespace {
+
+constexpr ::std::array<::std::uint8_t, 2> kJeOpcode = {
+    0x0F, 0x84,
+};
+
+__declspec(naked) void __cdecl InterceptionFunc01() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2GFX_IsNeedResizeWindowPatch));
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
+
+  // Original code, affects a `je` op.
+  ASM_X86(cmp eax, 0);
+
+  ASM_X86(ret);
+}
+
+} // namespace
+
+IsNeedResizeWindowPatch_1_13C::IsNeedResizeWindowPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void IsNeedResizeWindowPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void IsNeedResizeWindowPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+std::vector<mapi::GamePatch>
+IsNeedResizeWindowPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBufferPatch(
+          patch_address_and_size_02.first,
+          kJeOpcode.data(),
+          patch_address_and_size_02.second
+      )
+  );
+
+  return patches;
+}
+
+IsNeedResizeWindowPatch_1_13C::PatchAddressAndSize
+IsNeedResizeWindowPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+        ::mapi::GameAddress::FromOffset(
+            ::d2::DefaultLibrary::kD2GFX,
+            0x83CE
+        ),
+        0x8409 - 0x83CE
+      );
+    }
+  }
+}
+
+IsNeedResizeWindowPatch_1_13C::PatchAddressAndSize
+IsNeedResizeWindowPatch_1_13C::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+        ::mapi::GameAddress::FromOffset(
+            ::d2::DefaultLibrary::kD2GFX,
+            0x8409
+        ),
+        kJeOpcode.size()
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2gfx

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window_patch_1_13c.hpp
@@ -1,0 +1,80 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESIZE_WINDOW_PATCH_D2GFX_IS_NEED_RESIZE_WINDOW_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESIZE_WINDOW_PATCH_D2GFX_IS_NEED_RESIZE_WINDOW_PATCH_1_13C_HPP_
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr::patches::d2gfx {
+
+class IsNeedResizeWindowPatch_1_13C {
+ public:
+  IsNeedResizeWindowPatch_1_13C();
+
+  void Apply();
+  void Remove();
+
+ private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
+  std::vector<mapi::GamePatch> patches_;
+
+  static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
+};
+
+} // namespace sgd2fr::patches::d2gfx
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESIZE_WINDOW_PATCH_D2GFX_IS_NEED_RESIZE_WINDOW_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window.cc
@@ -1,0 +1,84 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2gfx_is_need_restore_down_window.hpp"
+
+#include <mdc/error/exit_on_error.hpp>
+#include <mdc/wchar_t/filew.h>
+#include <sgd2mapi.hpp>
+
+#include "../../../helper/game_resolution.hpp"
+
+namespace sgd2fr::patches {
+
+int __cdecl Sgd2fr_D2GFX_IsNeedRestoreDownWindowPatch() {
+  RECT client_rect = { 0 };
+
+  BOOL is_get_client_rect_success = GetClientRect(
+      ::d2::d2gfx::GetWindowHandle(),
+      &client_rect
+  );
+
+  if (!is_get_client_rect_success) {
+    ::mdc::error::ExitOnWindowsFunctionError(
+        __FILEW__,
+        __LINE__,
+        L"GetClientRect",
+        GetLastError()
+    );
+
+    return false;
+  }
+
+  ::std::tuple ingame_resolution = GetVideoModeDisplayResolution();
+
+  int client_width = client_rect.right - client_rect.left;
+  int client_height = client_rect.bottom - client_rect.top;
+
+  return (client_width <= ::std::get<0>(ingame_resolution)
+      && client_height <= ::std::get<1>(ingame_resolution));
+}
+
+} // namespace sgd2fr::patches

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window.hpp
@@ -1,0 +1,59 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_PATCH_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_PATCH_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_HPP_
+
+#include <windows.h>
+
+#include <cstdint>
+
+namespace sgd2fr::patches {
+
+extern "C" int __cdecl Sgd2fr_D2GFX_IsNeedRestoreDownWindowPatch();
+
+} // namespace sgd2fr::patches
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_PATCH_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window_patch.cc
@@ -1,0 +1,85 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2gfx_is_need_restore_down_window_patch.hpp"
+
+namespace sgd2fr::patches::d2gfx {
+
+IsNeedRestoreDownWindowPatch::IsNeedRestoreDownWindowPatch()
+  : patch_(MakePatch()) {
+}
+
+void IsNeedRestoreDownWindowPatch::Apply() {
+  if (this->patch_.has_value()) {
+    std::visit([](auto& patch) {
+      patch.Apply();
+    }, this->patch_.value());
+  }
+}
+
+void IsNeedRestoreDownWindowPatch::Remove() {
+  if (this->patch_.has_value()) {
+    std::visit([](auto& patch) {
+      patch.Remove();
+    }, this->patch_.value());
+  }
+}
+
+IsNeedRestoreDownWindowPatch::PatchType
+IsNeedRestoreDownWindowPatch::MakePatch() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  if (running_game_version < ::d2::GameVersion::k1_13C) {
+    return ::std::nullopt;
+  }
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return IsNeedRestoreDownWindowPatch_1_13C();
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2gfx

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window_patch.hpp
@@ -1,0 +1,78 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_PATCH_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_PATCH_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_PATCH_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_PATCH_HPP_
+
+#include <optional>
+#include <variant>
+
+#include <sgd2mapi.hpp>
+#include "d2gfx_is_need_restore_down_window_patch_1_13c.hpp"
+
+namespace sgd2fr::patches::d2gfx {
+
+class IsNeedRestoreDownWindowPatch {
+ public:
+  using PatchVariant = std::variant<
+      IsNeedRestoreDownWindowPatch_1_13C
+  >;
+
+  using PatchType = ::std::optional<PatchVariant>;
+
+  IsNeedRestoreDownWindowPatch();
+
+  void Apply();
+  void Remove();
+
+ private:
+  PatchType patch_;
+
+  static PatchType MakePatch();
+};
+
+} // namespace sgd2fr::patches::d2gfx
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_PATCH_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_PATCH_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window_patch_1_13c.cc
@@ -1,0 +1,160 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2gfx_is_need_restore_down_window_patch_1_13c.hpp"
+
+#include <array>
+
+#include "../../../asm_x86_macro.h"
+#include "d2gfx_is_need_restore_down_window.hpp"
+
+namespace sgd2fr::patches::d2gfx {
+namespace {
+
+constexpr ::std::array<::std::uint8_t, 2> kJeOpcode = {
+    0x0F, 0x84,
+};
+
+__declspec(naked) void __cdecl InterceptionFunc01() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2GFX_IsNeedRestoreDownWindowPatch));
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
+
+  // Original code, affects a `je` op.
+  ASM_X86(cmp eax, 0);
+
+  ASM_X86(ret);
+}
+
+} // namespace
+
+IsNeedRestoreDownWindowPatch_1_13C::IsNeedRestoreDownWindowPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void IsNeedRestoreDownWindowPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void IsNeedRestoreDownWindowPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+std::vector<mapi::GamePatch>
+IsNeedRestoreDownWindowPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBufferPatch(
+          patch_address_and_size_02.first,
+          kJeOpcode.data(),
+          patch_address_and_size_02.second
+      )
+  );
+
+  return patches;
+}
+
+IsNeedRestoreDownWindowPatch_1_13C::PatchAddressAndSize
+IsNeedRestoreDownWindowPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+        ::mapi::GameAddress::FromOffset(
+            ::d2::DefaultLibrary::kD2GFX,
+            0x811B
+        ),
+        0x815A - 0x811B
+      );
+    }
+  }
+}
+
+IsNeedRestoreDownWindowPatch_1_13C::PatchAddressAndSize
+IsNeedRestoreDownWindowPatch_1_13C::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+        ::mapi::GameAddress::FromOffset(
+            ::d2::DefaultLibrary::kD2GFX,
+            0x815A
+        ),
+        kJeOpcode.size()
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2gfx

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window_patch_1_13c.hpp
@@ -1,0 +1,80 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_PATCH_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_PATCH_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_PATCH_1_13C_HPP_
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr::patches::d2gfx {
+
+class IsNeedRestoreDownWindowPatch_1_13C {
+ public:
+  IsNeedRestoreDownWindowPatch_1_13C();
+
+  void Apply();
+  void Remove();
+
+ private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
+  std::vector<mapi::GamePatch> patches_;
+
+  static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
+};
+
+} // namespace sgd2fr::patches::d2gfx
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_PATCH_D2GFX_IS_NEED_RESTORE_DOWN_WINDOW_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch.cc
@@ -65,11 +65,15 @@ void SetDisplayWidthAndHeightPatch::Remove() {
 
 SetDisplayWidthAndHeightPatch::PatchVariant
 SetDisplayWidthAndHeightPatch::MakePatch() {
-  ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_09D: {
       return SetDisplayWidthAndHeightPatch_1_09D();
+    }
+
+    case ::d2::GameVersion::k1_13C: {
+      return SetDisplayWidthAndHeightPatch_1_13C();
     }
   }
 }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch.hpp
@@ -50,13 +50,15 @@
 
 #include <sgd2mapi.hpp>
 #include "d2gfx_set_display_width_and_height_patch_1_09d.hpp"
+#include "d2gfx_set_display_width_and_height_patch_1_13c.hpp"
 
 namespace sgd2fr::patches::d2gfx {
 
 class SetDisplayWidthAndHeightPatch {
  public:
   using PatchVariant = std::variant<
-      SetDisplayWidthAndHeightPatch_1_09D
+      SetDisplayWidthAndHeightPatch_1_09D,
+      SetDisplayWidthAndHeightPatch_1_13C
   >;
 
   SetDisplayWidthAndHeightPatch();

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch_1_09d.cc
@@ -51,7 +51,7 @@
 namespace sgd2fr::patches::d2gfx {
 namespace {
 
-__declspec(naked) void __cdecl InterceptionFunc_01() {
+__declspec(naked) void __cdecl InterceptionFunc01() {
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
@@ -99,21 +99,35 @@ std::vector<mapi::GamePatch>
 SetDisplayWidthAndHeightPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
-  mapi::GameAddress game_address_01 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2GFX,
-      0x4B80
-  );
-
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          std::move(game_address_01),
+          patch_address_and_size_01.first,
           mapi::BranchType::kCall,
-          &InterceptionFunc_01,
-          0x4BB8 - 0x4B80
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
       )
   );
 
   return patches;
+}
+
+SetDisplayWidthAndHeightPatch_1_09D::PatchAddressAndSize
+SetDisplayWidthAndHeightPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GFX,
+              0x4B80
+          ),
+          0x4BB8 - 0x4B80
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2gfx

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_REQUIRED_D2GFX_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2GFX_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_REQUIRED_D2GFX_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2GFX_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,9 +62,16 @@ class SetDisplayWidthAndHeightPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
 };
 
 } // namespace sgd2fr::patches::d2gfx

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch_1_13c.cc
@@ -1,0 +1,125 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2gfx_set_display_width_and_height_patch_1_13c.hpp"
+
+#include "../../../asm_x86_macro.h"
+#include "d2gfx_set_display_width_and_height.hpp"
+
+namespace sgd2fr::patches::d2gfx {
+namespace {
+
+__declspec(naked) void __cdecl InterceptionFunc01() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(push ecx);
+
+  ASM_X86(push dword ptr [ebp + 20]);
+  ASM_X86(push dword ptr [ebp + 16]);
+  ASM_X86(push dword ptr [ebp + 12]);
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2GFX_SetDisplayWidthAndHeight));
+  ASM_X86(add esp, 12);
+
+  ASM_X86(pop ecx);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+} // namespace
+
+SetDisplayWidthAndHeightPatch_1_13C::SetDisplayWidthAndHeightPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void SetDisplayWidthAndHeightPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void SetDisplayWidthAndHeightPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+std::vector<mapi::GamePatch>
+SetDisplayWidthAndHeightPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  return patches;
+}
+
+SetDisplayWidthAndHeightPatch_1_13C::PatchAddressAndSize
+SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+        ::mapi::GameAddress::FromOffset(
+            ::d2::DefaultLibrary::kD2GFX,
+            0x7FD0
+        ),
+        0x7FF4 - 0x7FD0
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2gfx

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch_1_13c.hpp
@@ -1,0 +1,79 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2GFX_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2GFX_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2GFX_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2GFX_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr::patches::d2gfx {
+
+class SetDisplayWidthAndHeightPatch_1_13C {
+ public:
+  SetDisplayWidthAndHeightPatch_1_13C();
+
+  void Apply();
+  void Remove();
+
+ private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
+  std::vector<mapi::GamePatch> patches_;
+
+  static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+};
+
+} // namespace sgd2fr::patches::d2gfx
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2GFX_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2GFX_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height.cc
@@ -79,6 +79,7 @@ void __cdecl Sgd2fr_D2Glide_SetDisplayWidthAndHeight(
 
     default: {
       *glide_res_id = 0x1000 + (resolution_mode - 3);
+      break;
     }
   }
 }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch.cc
@@ -80,6 +80,10 @@ SetDisplayWidthAndHeightPatch::MakePatch() {
     case d2::GameVersion::k1_09D: {
       return SetDisplayWidthAndHeightPatch_1_09D();
     }
+
+    case d2::GameVersion::k1_13C: {
+      return SetDisplayWidthAndHeightPatch_1_13C();
+    }
   }
 }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch.hpp
@@ -52,13 +52,15 @@
 
 #include <sgd2mapi.hpp>
 #include "d2glide_set_display_width_and_height_patch_1_09d.hpp"
+#include "d2glide_set_display_width_and_height_patch_1_13c.hpp"
 
 namespace sgd2fr::patches::d2glide {
 
 class SetDisplayWidthAndHeightPatch {
  public:
   using PatchVariant = std::variant<
-      SetDisplayWidthAndHeightPatch_1_09D
+      SetDisplayWidthAndHeightPatch_1_09D,
+      SetDisplayWidthAndHeightPatch_1_13C
   >;
 
   using PatchType = std::optional<PatchVariant>;

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_09d.cc
@@ -93,7 +93,7 @@ __declspec(naked) void __cdecl InterceptionFunc_01() {
  * cmp eax, 1
  * jne D2Glide.dll+1BD1
  */
-constexpr std::array<std::uint8_t, 10> kPatchBuffer_02 = {
+constexpr std::array<std::uint8_t, 10> kPatchBuffer02 = {
     0x90, 0x90, 0x90, 0x90, 0x90, 0x83, 0xF8, 0x01, 0x75, 0x11
 };
 
@@ -119,34 +119,62 @@ std::vector<mapi::GamePatch>
 SetDisplayWidthAndHeightPatch_1_09D::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
-  mapi::GameAddress game_address_01 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Glide,
-      0x1B8B
-  );
-
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          std::move(game_address_01),
+          patch_address_and_size_01.first,
           mapi::BranchType::kCall,
           &InterceptionFunc_01,
-          0x1B9F - 0x1B8B
+          patch_address_and_size_01.second
       )
   );
 
-  mapi::GameAddress game_address_02 = mapi::GameAddress::FromOffset(
-      ::d2::DefaultLibrary::kD2Glide,
-      0x1BB6
-  );
-
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
   patches.push_back(
       mapi::GamePatch::MakeGameBufferPatch(
-          std::move(game_address_02),
-          kPatchBuffer_02.cbegin(),
-          kPatchBuffer_02.end()
+          patch_address_and_size_02.first,
+          kPatchBuffer02.data(),
+          patch_address_and_size_02.second
       )
   );
 
   return patches;
+}
+
+SetDisplayWidthAndHeightPatch_1_09D::PatchAddressAndSize
+SetDisplayWidthAndHeightPatch_1_09D::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x1B8B
+          ),
+          0x1B9F - 0x1B8B
+      );
+    }
+  }
+}
+
+SetDisplayWidthAndHeightPatch_1_09D::PatchAddressAndSize
+SetDisplayWidthAndHeightPatch_1_09D::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x1BB6
+          ),
+          kPatchBuffer02.size()
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::d2glide

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_09d.hpp
@@ -46,6 +46,8 @@
 #ifndef SGD2FR_PATCHES_REQUIRED_D2GLIDE_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2GLIDE_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_09D_HPP_
 #define SGD2FR_PATCHES_REQUIRED_D2GLIDE_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2GLIDE_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_09D_HPP_
 
+#include <cstddef>
+#include <utility>
 #include <vector>
 
 #include <sgd2mapi.hpp>
@@ -60,9 +62,17 @@ class SetDisplayWidthAndHeightPatch_1_09D {
   void Remove();
 
  private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
 };
 
 } // namespace sgd2fr::patches::d2glide

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_13c.cc
@@ -1,0 +1,198 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2glide_set_display_width_and_height_patch_1_13c.hpp"
+
+#include <array>
+
+#include "../../../asm_x86_macro.h"
+#include "d2glide_set_display_width_and_height.hpp"
+
+namespace sgd2fr::patches::d2glide {
+namespace {
+
+__declspec(naked) void __cdecl InterceptionFunc_01() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(sub esp, 12);
+
+  ASM_X86(push eax);
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(lea eax, dword ptr [ebp - 12]);
+  ASM_X86(push eax);
+  ASM_X86(lea ecx, dword ptr [ebp - 8]);
+  ASM_X86(push ecx);
+  ASM_X86(lea edx, dword ptr [ebp - 4]);
+  ASM_X86(push edx);
+  ASM_X86(push esi);
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2Glide_SetDisplayWidthAndHeight));
+  ASM_X86(add esp, 16);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+  ASM_X86(pop eax);
+
+  ASM_X86(mov ecx, dword ptr [ebp - 12]);
+
+  ASM_X86(add esp, 12);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+constexpr ::std::uint8_t kJeOpcode = 0x74;
+constexpr ::std::uint8_t k01Byte = 0x01;
+
+} // namespace
+
+SetDisplayWidthAndHeightPatch_1_13C::SetDisplayWidthAndHeightPatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void SetDisplayWidthAndHeightPatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void SetDisplayWidthAndHeightPatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+std::vector<mapi::GamePatch>
+SetDisplayWidthAndHeightPatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc_01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBufferPatch(
+          patch_address_and_size_02.first,
+          &k01Byte,
+          patch_address_and_size_02.second
+      )
+  );
+
+  PatchAddressAndSize patch_address_and_size_03 =
+      GetPatchAddressAndSize03();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBufferPatch(
+          patch_address_and_size_03.first,
+          &kJeOpcode,
+          patch_address_and_size_03.second
+      )
+  );
+
+  return patches;
+}
+
+SetDisplayWidthAndHeightPatch_1_13C::PatchAddressAndSize
+SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0xDCF1
+          ),
+          0xDD0A - 0xDCF1
+      );
+    }
+  }
+}
+
+SetDisplayWidthAndHeightPatch_1_13C::PatchAddressAndSize
+SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0xDD15 + 2
+          ),
+          sizeof(k01Byte)
+      );
+    }
+  }
+}
+
+SetDisplayWidthAndHeightPatch_1_13C::PatchAddressAndSize
+SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize03() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0xDD1E
+          ),
+          sizeof(kJeOpcode)
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2glide

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_13c.hpp
@@ -1,0 +1,81 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2GLIDE_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2GLIDE_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2GLIDE_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2GLIDE_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr::patches::d2glide {
+
+class SetDisplayWidthAndHeightPatch_1_13C {
+ public:
+  SetDisplayWidthAndHeightPatch_1_13C();
+
+  void Apply();
+  void Remove();
+
+ private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
+  std::vector<mapi::GamePatch> patches_;
+
+  static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
+  static PatchAddressAndSize GetPatchAddressAndSize03();
+};
+
+} // namespace sgd2fr::patches::d2glide
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2GLIDE_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_D2GLIDE_SET_DISPLAY_WIDTH_AND_HEIGHT_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize.cc
@@ -1,0 +1,91 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2win_resize_window_on_maximize.hpp"
+
+#include <cmath>
+#include <numeric>
+
+#include <sgd2mapi.hpp>
+
+#include "../../../helper/game_resolution.hpp"
+
+namespace sgd2fr::patches {
+
+void __cdecl Sgd2fr_D2Win_ResizeWindowOnMaximize(
+    ::std::int32_t desktop_width,
+    ::std::int32_t desktop_height,
+    ::std::int32_t* window_width,
+    ::std::int32_t* window_height
+) {
+  int window_resolution_gcd = ::std::gcd(*window_width, *window_height);
+
+  int lowest_width = *window_width / window_resolution_gcd;
+  int lowest_height = *window_height / window_resolution_gcd;
+
+  // Subtract 9 from height, to keep behavior consistent with D2.
+  constexpr int height_subtract_amount = 9;
+
+  double desktop_width_increment_count = static_cast<double>(desktop_width)
+      / lowest_width;
+  double desktop_height_increment_count = static_cast<double>(
+      desktop_height - height_subtract_amount
+  ) / lowest_height;
+
+  double window_resolution_increment_count =
+      (desktop_width_increment_count <= desktop_height_increment_count)
+          ? desktop_width_increment_count
+          : desktop_height_increment_count;
+
+  *window_width = static_cast<int>(
+      ::std::round(window_resolution_increment_count * lowest_width)
+  );
+
+  *window_height = static_cast<int>(
+      ::std::round(window_resolution_increment_count * lowest_height)
+  );
+}
+
+} // namespace sgd2fr::patches

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize.hpp
@@ -1,0 +1,62 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_PATCH_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_PATCH_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_HPP_
+
+#include <cstdint>
+
+namespace sgd2fr::patches {
+
+extern "C" void __cdecl Sgd2fr_D2Win_ResizeWindowOnMaximize(
+    ::std::int32_t desktop_width,
+    ::std::int32_t desktop_height,
+    ::std::int32_t* window_width,
+    ::std::int32_t* window_height
+);
+
+} // namespace sgd2fr::patches
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_PATCH_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch.cc
@@ -1,0 +1,81 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2win_resize_window_on_maximize_patch.hpp"
+
+namespace sgd2fr::patches::d2win {
+
+ResizeWindowOnMaximizePatch::ResizeWindowOnMaximizePatch()
+  : patch_(MakePatch()) {
+}
+
+void ResizeWindowOnMaximizePatch::Apply() {
+  if (this->patch_.has_value()) {
+    std::visit([](auto& patch) {
+      patch.Apply();
+    }, this->patch_.value());
+  }
+}
+
+void ResizeWindowOnMaximizePatch::Remove() {
+  if (this->patch_.has_value()) {
+    std::visit([](auto& patch) {
+      patch.Remove();
+    }, this->patch_.value());
+  }
+}
+
+ResizeWindowOnMaximizePatch::PatchType
+ResizeWindowOnMaximizePatch::MakePatch() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return ResizeWindowOnMaximizePatch_1_13C();
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2win

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch.hpp
@@ -1,0 +1,78 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_PATCH_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_PATCH_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_PATCH_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_PATCH_HPP_
+
+#include <optional>
+#include <variant>
+
+#include <sgd2mapi.hpp>
+#include "d2win_resize_window_on_maximize_patch_1_13c.hpp"
+
+namespace sgd2fr::patches::d2win {
+
+class ResizeWindowOnMaximizePatch {
+ public:
+  using PatchVariant = std::variant<
+      ResizeWindowOnMaximizePatch_1_13C
+  >;
+
+  using PatchType = ::std::optional<PatchVariant>;
+
+  ResizeWindowOnMaximizePatch();
+
+  void Apply();
+  void Remove();
+
+ private:
+  PatchType patch_;
+
+  static PatchType MakePatch();
+};
+
+} // namespace sgd2fr::patches::d2win
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_PATCH_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_PATCH_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch_1_13c.cc
@@ -1,0 +1,167 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "d2win_resize_window_on_maximize_patch_1_13c.hpp"
+
+#include "../../../asm_x86_macro.h"
+#include "d2win_resize_window_on_maximize.hpp"
+
+namespace sgd2fr::patches::d2win {
+namespace {
+
+__declspec(naked) void __cdecl InterceptionFunc01() {
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
+
+  ASM_X86(sub esp, 8);
+  ASM_X86(mov dword ptr [ebp - 4], ecx);
+  ASM_X86(mov dword ptr [ebp - 8], esi);
+
+  ASM_X86(push eax);
+  ASM_X86(push ecx);
+  ASM_X86(push edx);
+
+  ASM_X86(lea eax, dword ptr [ebp - 8]);
+  ASM_X86(push eax);
+  ASM_X86(lea ecx, dword ptr [ebp - 4]);
+  ASM_X86(push ecx);
+  // The old ebp stores the value to be pushed.
+  ASM_X86(push dword ptr [ebp]);
+  ASM_X86(push edi);
+  ASM_X86(call ASM_X86_FUNC(Sgd2fr_D2Win_ResizeWindowOnMaximize));
+  ASM_X86(add esp, 16);
+
+  ASM_X86(pop edx);
+  ASM_X86(pop ecx);
+  ASM_X86(pop eax);
+
+  ASM_X86(mov ecx, dword ptr [ebp - 4]);
+  ASM_X86(mov esi, dword ptr [ebp - 8]);
+  ASM_X86(add esp, 8);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+} // namespace
+
+ResizeWindowOnMaximizePatch_1_13C::ResizeWindowOnMaximizePatch_1_13C()
+  : patches_(MakePatches()) {
+}
+
+void ResizeWindowOnMaximizePatch_1_13C::Apply() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+void ResizeWindowOnMaximizePatch_1_13C::Remove() {
+  for (auto& patch : this->patches_) {
+    patch.Apply();
+  }
+}
+
+std::vector<mapi::GamePatch>
+ResizeWindowOnMaximizePatch_1_13C::MakePatches() {
+  std::vector<mapi::GamePatch> patches;
+
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          patch_address_and_size_01.first,
+          mapi::BranchType::kCall,
+          &InterceptionFunc01,
+          patch_address_and_size_01.second
+      )
+  );
+
+  PatchAddressAndSize patch_address_and_size_02 =
+      GetPatchAddressAndSize02();
+  patches.push_back(
+      mapi::GamePatch::MakeGameNopPatch(
+          patch_address_and_size_02.first,
+          patch_address_and_size_02.second
+      )
+  );
+
+  return patches;
+}
+
+ResizeWindowOnMaximizePatch_1_13C::PatchAddressAndSize
+ResizeWindowOnMaximizePatch_1_13C::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+        ::mapi::GameAddress::FromOffset(
+            ::d2::DefaultLibrary::kD2Win,
+            0x175C8
+        ),
+        0x175D9 - 0x175C8
+      );
+    }
+  }
+}
+
+ResizeWindowOnMaximizePatch_1_13C::PatchAddressAndSize
+ResizeWindowOnMaximizePatch_1_13C::GetPatchAddressAndSize02() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+        ::mapi::GameAddress::FromOffset(
+            ::d2::DefaultLibrary::kD2Win,
+            0x175E6
+        ),
+        0x175E9 - 0x175E6
+      );
+    }
+  }
+}
+
+} // namespace sgd2fr::patches::d2win

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch_1_13c.hpp
@@ -1,0 +1,80 @@
+/**
+ * SlashGaming Diablo II Free Resolution
+ * Copyright (C) 2019-2021  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Resolution.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#ifndef SGD2FR_PATCHES_REQUIRED_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_PATCH_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_PATCH_1_13C_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_PATCH_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_PATCH_1_13C_HPP_
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fr::patches::d2win {
+
+class ResizeWindowOnMaximizePatch_1_13C {
+ public:
+  ResizeWindowOnMaximizePatch_1_13C();
+
+  void Apply();
+  void Remove();
+
+ private:
+  using PatchAddressAndSize = ::std::pair<
+      ::mapi::GameAddress,
+      ::std::size_t
+  >;
+
+  std::vector<mapi::GamePatch> patches_;
+
+  static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+  static PatchAddressAndSize GetPatchAddressAndSize02();
+};
+
+} // namespace sgd2fr::patches::d2win
+
+#endif // SGD2FR_PATCHES_REQUIRED_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_PATCH_D2WIN_RESIZE_WINDOW_ON_MAXIMIZE_PATCH_1_13C_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open.cc
@@ -74,6 +74,17 @@ void __cdecl Sgd2fr_Glide3x_SetWindowWidthAndHeight(
       break;
     }
 
+    case Glide3xVersion::kSven1_4_6_1: {
+      width = *reinterpret_cast<std::int32_t**>(
+          mapi::GameAddress::FromOffset("glide3x.dll", 0x1C870).raw_address()
+      );
+      height = *reinterpret_cast<std::int32_t**>(
+          mapi::GameAddress::FromOffset("glide3x.dll", 0x1C830).raw_address()
+      );
+
+      break;
+    }
+
     case Glide3xVersion::kSven1_4_8_3: {
       width = *reinterpret_cast<std::int32_t**>(
           mapi::GameAddress::FromOffset("glide3x.dll", 0x1D870).raw_address()

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch.cc
@@ -79,7 +79,8 @@ GrSstWinOpenPatch::MakePatch() {
   Glide3xVersion running_glide3x_version = glide3x_version::GetRunning();
 
   switch (running_glide3x_version) {
-    case Glide3xVersion::kSven1_4_4_21: {
+    case Glide3xVersion::kSven1_4_4_21:
+    case Glide3xVersion::kSven1_4_6_1: {
       return GrSstWinOpenPatch_Sven_1_4_4_21();
     }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch_sven_1_4_4_21.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch_sven_1_4_4_21.cc
@@ -47,26 +47,17 @@
 
 #include <array>
 
-#include "../../../asm_x86_macro.h"
+#include "../../../helper/glide3x_version.hpp"
 #include "glide3x_gr_sst_win_open.hpp"
 
 namespace sgd2fr::patches::glide3x {
 namespace {
 
-__declspec(naked) void __cdecl InterceptionFunc() {
-  ASM_X86(push ebp);
-  ASM_X86(mov ebp, esp);
+extern "C" {
 
-  ASM_X86(add eax, 258);
+void __cdecl Glide3x_GrSstWinOpenPatch_Sven_1_4_4_21_InterceptionFunc01();
 
-  ASM_X86(sub esp, 8);
-  ASM_X86(push eax);
-  ASM_X86(call ASM_X86_FUNC(Sgd2fr_Glide3x_SetWindowWidthAndHeight));
-  ASM_X86(add esp, 12);
-
-  ASM_X86(leave);
-  ASM_X86(ret);
-}
+} // extern "C"
 
 } // namespace
 
@@ -90,21 +81,45 @@ std::vector<mapi::GamePatch>
 GrSstWinOpenPatch_Sven_1_4_4_21::MakePatches() {
   std::vector<mapi::GamePatch> patches;
 
-  mapi::GameAddress game_address = mapi::GameAddress::FromOffset(
-      "glide3x.dll",
-      0xCBA9
-  );
-
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
   patches.push_back(
       mapi::GamePatch::MakeGameBranchPatch(
-          std::move(game_address),
+          patch_address_and_size_01.first,
           mapi::BranchType::kCall,
-          &InterceptionFunc,
-          0xCBB0 - 0xCBA9
+          &Glide3x_GrSstWinOpenPatch_Sven_1_4_4_21_InterceptionFunc01,
+          patch_address_and_size_01.second
       )
   );
 
   return patches;
+}
+
+PatchAddressAndSize
+GrSstWinOpenPatch_Sven_1_4_4_21::GetPatchAddressAndSize01() {
+  Glide3xVersion running_glide3x_version = glide3x_version::GetRunning();
+
+  switch (running_glide3x_version) {
+    case Glide3xVersion::kSven1_4_4_21: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              L"glide3x.dll",
+              0xCBA9
+          ),
+          0xCBB0 - 0xCBA9
+      );
+    }
+
+    case Glide3xVersion::kSven1_4_6_1: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              L"glide3x.dll",
+              0xCAD5
+          ),
+          0xCADC - 0xCAD5
+      );
+    }
+  }
 }
 
 } // namespace sgd2fr::patches::glide3x

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch_sven_1_4_4_21.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch_sven_1_4_4_21.hpp
@@ -49,6 +49,7 @@
 #include <vector>
 
 #include <sgd2mapi.hpp>
+#include "../../../helper/patch_address_and_size.hpp"
 
 namespace sgd2fr::patches::glide3x {
 
@@ -63,6 +64,8 @@ class GrSstWinOpenPatch_Sven_1_4_4_21 {
   std::vector<mapi::GamePatch> patches_;
 
   static std::vector<mapi::GamePatch> MakePatches();
+
+  static PatchAddressAndSize GetPatchAddressAndSize01();
 };
 
 } // namespace sgd2fr::patches::glide3x

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch_sven_1_4_4_21_asm.asm
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch_sven_1_4_4_21_asm.asm
@@ -1,0 +1,72 @@
+;
+; SlashGaming Diablo II Free Resolution
+; Copyright (C) 2019-2021  Mir Drualga
+;
+; This file is part of SlashGaming Diablo II Free Resolution.
+;
+;  This program is free software: you can redistribute it and/or modify
+;  it under the terms of the GNU Affero General Public License as published
+;  by the Free Software Foundation, either version 3 of the License, or
+;  (at your option) any later version.
+;
+;  This program is distributed in the hope that it will be useful,
+;  but WITHOUT ANY WARRANTY; without even the implied warranty of
+;  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;  GNU Affero General Public License for more details.
+;
+;  You should have received a copy of the GNU Affero General Public License
+;  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;
+;  Additional permissions under GNU Affero General Public License version 3
+;  section 7
+;
+;  If you modify this Program, or any covered work, by linking or combining
+;  it with Diablo II (or a modified version of that game and its
+;  libraries), containing parts covered by the terms of Blizzard End User
+;  License Agreement, the licensors of this Program grant you additional
+;  permission to convey the resulting work. This additional permission is
+;  also extended to any combination of expansions, mods, and remasters of
+;  the game.
+;
+;  If you modify this Program, or any covered work, by linking or combining
+;  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+;  Glide, OpenGL, or Rave wrapper (or modified versions of those
+;  libraries), containing parts not covered by a compatible license, the
+;  licensors of this Program grant you additional permission to convey the
+;  resulting work.
+;
+;  If you modify this Program, or any covered work, by linking or combining
+;  it with any library (or a modified version of that library) that links
+;  to Diablo II (or a modified version of that game and its libraries),
+;  containing parts not covered by a compatible license, the licensors of
+;  this Program grant you additional permission to convey the resulting
+;  work.
+;
+
+global _Glide3x_GrSstWinOpenPatch_Sven_1_4_4_21_InterceptionFunc01
+
+extern _Sgd2fr_Glide3x_SetWindowWidthAndHeight
+
+section .data
+
+section .bss
+
+section .text
+
+;
+; External
+;
+
+_Glide3x_GrSstWinOpenPatch_Sven_1_4_4_21_InterceptionFunc01:
+    push ebp
+    mov ebp, esp
+
+    add eax, 258
+
+    sub esp, 8
+    push eax
+    call _Sgd2fr_Glide3x_SetWindowWidthAndHeight
+    add esp, 12
+
+    leave
+    ret

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/required_patches.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/required_patches.cc
@@ -61,10 +61,14 @@ void RequiredPatches::Apply() {
   this->d2ddraw_set_bit_block_width_and_height_patch_.Apply();
   this->d2ddraw_set_cel_display_left_and_right_patch_.Apply();
   this->d2ddraw_set_display_width_and_height_patch_.Apply();
+  this->d2direct3d_set_display_width_and_height_patch_.Apply();
   this->d2gdi_set_bit_block_width_and_height_patch_.Apply();
   this->d2gdi_set_cel_display_left_and_right_patch_.Apply();
+  this->d2gfx_is_need_resize_window_patch_.Apply();
+  this->d2gfx_is_need_restore_down_window_patch_.Apply();
   this->d2gfx_set_display_width_and_height_patch_.Apply();
   this->d2glide_set_display_width_and_height_patch_.Apply();
+  this->d2win_resize_window_on_maximize_patch_.Apply();
   this->gr_sst_win_open_patch_.Apply();
 }
 
@@ -80,10 +84,14 @@ void RequiredPatches::Remove() {
   this->d2ddraw_set_bit_block_width_and_height_patch_.Remove();
   this->d2ddraw_set_cel_display_left_and_right_patch_.Remove();
   this->d2ddraw_set_display_width_and_height_patch_.Remove();
+  this->d2direct3d_set_display_width_and_height_patch_.Remove();
   this->d2gdi_set_bit_block_width_and_height_patch_.Remove();
   this->d2gdi_set_cel_display_left_and_right_patch_.Remove();
+  this->d2gfx_is_need_resize_window_patch_.Remove();
+  this->d2gfx_is_need_restore_down_window_patch_.Remove();
   this->d2gfx_set_display_width_and_height_patch_.Remove();
   this->d2glide_set_display_width_and_height_patch_.Remove();
+  this->d2win_resize_window_on_maximize_patch_.Remove();
   this->gr_sst_win_open_patch_.Remove();
 }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/required_patches.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/required_patches.hpp
@@ -61,8 +61,11 @@
 #include "d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch.hpp"
 #include "d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch.hpp"
 #include "d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch.hpp"
+#include "d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window_patch.hpp"
+#include "d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window_patch.hpp"
 #include "d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch.hpp"
 #include "d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch.hpp"
+#include "d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch.hpp"
 #include "glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch.hpp"
 
 namespace sgd2fr::patches {
@@ -117,11 +120,20 @@ class RequiredPatches {
   d2gdi::SetCelDisplayLeftAndRightPatch
       d2gdi_set_cel_display_left_and_right_patch_;
 
+  d2gfx::IsNeedResizeWindowPatch
+      d2gfx_is_need_resize_window_patch_;
+
+  d2gfx::IsNeedRestoreDownWindowPatch
+      d2gfx_is_need_restore_down_window_patch_;
+
   d2gfx::SetDisplayWidthAndHeightPatch
       d2gfx_set_display_width_and_height_patch_;
 
   d2glide::SetDisplayWidthAndHeightPatch
       d2glide_set_display_width_and_height_patch_;
+
+  d2win::ResizeWindowOnMaximizePatch
+      d2win_resize_window_on_maximize_patch_;
 
   glide3x::GrSstWinOpenPatch
       gr_sst_win_open_patch_;


### PR DESCRIPTION
The following changes were made:
- Restore support for 1.13C.
- Support D2SE. Must be loaded using the PlugY.ini config.
- Fix video mode detection always incorrectly detecting DirectDraw when game video mode is not controlled by command line options.
- Fix default assets mismatch for the right screen's border.
- Fix potential bug that may result in the New Skill button not
  appearing correctly.

1.13C Only:
- Fix the aspect ratio window scaling when the maximize button is pressed. Previously, the maximize button only scaled for 4:3 aspect ratio even when the resolution's aspect ratio was different.
- Fix the restore down functionality when the maximize button is pressed. Previously, the button would prevent re-maximizing the game window when pressed.