### PR TITLE
Port video mode patches

### DIFF
--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch.cc
@@ -77,12 +77,28 @@ SetBitBlockWidthAndHeightPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_07Beta:
+    case ::d2::GameVersion::k1_07:
+    case ::d2::GameVersion::k1_08:
+    case ::d2::GameVersion::k1_09:
+    case ::d2::GameVersion::k1_09B:
+    case ::d2::GameVersion::k1_09D:
+    case ::d2::GameVersion::k1_10Beta:
+    case ::d2::GameVersion::k1_10SBeta:
+    case ::d2::GameVersion::k1_10:
+    case ::d2::GameVersion::kLod1_14A:
+    case ::d2::GameVersion::kLod1_14B:
+    case ::d2::GameVersion::kLod1_14C:
+    case ::d2::GameVersion::kLod1_14D: {
       return SetBitBlockWidthAndHeightPatch_1_09D();
     }
 
-    case d2::GameVersion::k1_13C:
-    case d2::GameVersion::k1_13D: {
+    case ::d2::GameVersion::k1_11:
+    case ::d2::GameVersion::k1_11B:
+    case ::d2::GameVersion::k1_12A:
+    case ::d2::GameVersion::k1_13ABeta:
+    case ::d2::GameVersion::k1_13C:
+    case ::d2::GameVersion::k1_13D: {
       return SetBitBlockWidthAndHeightPatch_1_13C();
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_09d.cc
@@ -85,15 +85,6 @@ SetBitBlockWidthAndHeightPatch_1_09D::MakePatches() {
       )
   );
 
-  PatchAddressAndSize patch_address_and_size_02 =
-      GetPatchAddressAndSize02();
-  patches.push_back(
-      mapi::GamePatch::MakeGameNopPatch(
-          patch_address_and_size_02.first,
-          patch_address_and_size_02.second
-      )
-  );
-
   return patches;
 }
 
@@ -102,6 +93,20 @@ SetBitBlockWidthAndHeightPatch_1_09D::GetPatchAddressAndSize01() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_07Beta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x17CF
+          ),
+          0x17F3 - 0x17CF
+      );
+    }
+
+    case ::d2::GameVersion::k1_07:
+    case ::d2::GameVersion::k1_08:
+    case ::d2::GameVersion::k1_09:
+    case ::d2::GameVersion::k1_09B:
     case ::d2::GameVersion::k1_09D: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
@@ -111,21 +116,65 @@ SetBitBlockWidthAndHeightPatch_1_09D::GetPatchAddressAndSize01() {
           0x1803 - 0x17DF
       );
     }
-  }
-}
 
-SetBitBlockWidthAndHeightPatch_1_09D::PatchAddressAndSize
-SetBitBlockWidthAndHeightPatch_1_09D::GetPatchAddressAndSize02() {
-  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
-
-  switch (running_game_version) {
-    case ::d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_10Beta:
+    case ::d2::GameVersion::k1_10SBeta: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
               ::d2::DefaultLibrary::kD2DDraw,
-              0x180A
+              0x17BF
           ),
-          0x1810 - 0x180A
+          0x17D9 - 0x17BF
+      );
+    }
+
+    case ::d2::GameVersion::k1_10: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x17AF
+          ),
+          0x17C9 - 0x17AF
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x31DDE
+          ),
+          0x31E0C - 0x31DDE
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x10F35E
+          ),
+          0x10F38C - 0x10F35E
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x10EF4E
+          ),
+          0x10EF7C - 0x10EF4E
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x111241
+          ),
+          0x11126F - 0x111241
       );
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_13c.cc
@@ -93,6 +93,46 @@ SetBitBlockWidthAndHeightPatch_1_13C::GetPatchAddressAndSize01() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_11: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x85D2
+          ),
+          0x85F6 - 0x85D2
+      );
+    }
+
+    case ::d2::GameVersion::k1_11B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x8082
+          ),
+          0x80A6 - 0x8082
+      );
+    }
+
+    case ::d2::GameVersion::k1_12A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x8CE2
+          ),
+          0x8D06 - 0x8CE2
+      );
+    }
+
+    case ::d2::GameVersion::k1_13ABeta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x75E2
+          ),
+          0x7606 - 0x75E2
+      );
+    }
+
     case ::d2::GameVersion::k1_13C: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_cel_display_left_and_right_patch/d2ddraw_set_cel_display_left_and_right_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_cel_display_left_and_right_patch/d2ddraw_set_cel_display_left_and_right_patch.cc
@@ -77,9 +77,25 @@ SetCelDisplayLeftAndRightPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case d2::GameVersion::k1_09D:
-    case d2::GameVersion::k1_13C:
-    case d2::GameVersion::k1_13D: {
+    case ::d2::GameVersion::k1_07Beta:
+    case ::d2::GameVersion::k1_07:
+    case ::d2::GameVersion::k1_08:
+    case ::d2::GameVersion::k1_09:
+    case ::d2::GameVersion::k1_09B:
+    case ::d2::GameVersion::k1_09D:
+    case ::d2::GameVersion::k1_10Beta:
+    case ::d2::GameVersion::k1_10SBeta:
+    case ::d2::GameVersion::k1_10:
+    case ::d2::GameVersion::k1_11:
+    case ::d2::GameVersion::k1_11B:
+    case ::d2::GameVersion::k1_12A:
+    case ::d2::GameVersion::k1_13ABeta:
+    case ::d2::GameVersion::k1_13C:
+    case ::d2::GameVersion::k1_13D:
+    case ::d2::GameVersion::kLod1_14A:
+    case ::d2::GameVersion::kLod1_14B:
+    case ::d2::GameVersion::kLod1_14C:
+    case ::d2::GameVersion::kLod1_14D: {
       return SetCelDisplayLeftAndRightPatch_1_09D();
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_cel_display_left_and_right_patch/d2ddraw_set_cel_display_left_and_right_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_cel_display_left_and_right_patch/d2ddraw_set_cel_display_left_and_right_patch_1_09d.cc
@@ -93,6 +93,29 @@ SetCelDisplayLeftAndRightPatch_1_09D::GetPatchAddressAndSize01() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_07Beta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x4410
+          ),
+          0x4430 - 0x4410
+      );
+    }
+
+    case ::d2::GameVersion::k1_07: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x4420
+          ),
+          0x4440 - 0x4420
+      );
+    }
+
+    case ::d2::GameVersion::k1_08:
+    case ::d2::GameVersion::k1_09:
+    case ::d2::GameVersion::k1_09B:
     case ::d2::GameVersion::k1_09D: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
@@ -100,6 +123,67 @@ SetCelDisplayLeftAndRightPatch_1_09D::GetPatchAddressAndSize01() {
               0x4430
           ),
           0x4450 - 0x4430
+      );
+    }
+
+    case ::d2::GameVersion::k1_10Beta:
+    case ::d2::GameVersion::k1_10SBeta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x43C0
+          ),
+          0x43E0 - 0x43C0
+      );
+    }
+
+    case ::d2::GameVersion::k1_10: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x43A0
+          ),
+          0x43C0 - 0x43A0
+      );
+    }
+
+    case ::d2::GameVersion::k1_11: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x7040
+          ),
+          0x7060 - 0x7040
+      );
+    }
+
+    case ::d2::GameVersion::k1_11B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x86E0
+          ),
+          0x8700 - 0x86E0
+      );
+    }
+
+    case ::d2::GameVersion::k1_12A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x6A50
+          ),
+          0x6A70 - 0x6A50
+      );
+    }
+
+    case ::d2::GameVersion::k1_13ABeta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x8CC0
+          ),
+          0x8CE0 - 0x8CC0
       );
     }
 
@@ -120,6 +204,46 @@ SetCelDisplayLeftAndRightPatch_1_09D::GetPatchAddressAndSize01() {
               0x8FE0
           ),
           0x9000 - 0x8FE0
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x329A0
+          ),
+          0x329C0 - 0x329A0
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x10FF20
+          ),
+          0x10FF40 - 0x10FF20
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x10FB10
+          ),
+          0x10FB30 - 0x10FB10
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x111DF0
+          ),
+          0x111E10 - 0x111DF0
       );
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch.cc
@@ -77,12 +77,28 @@ SetDisplayWidthAndHeightPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_07Beta:
+    case ::d2::GameVersion::k1_07:
+    case ::d2::GameVersion::k1_08:
+    case ::d2::GameVersion::k1_09:
+    case ::d2::GameVersion::k1_09B:
+    case ::d2::GameVersion::k1_09D:
+    case ::d2::GameVersion::k1_10Beta:
+    case ::d2::GameVersion::k1_10SBeta:
+    case ::d2::GameVersion::k1_10:
+    case ::d2::GameVersion::kLod1_14A:
+    case ::d2::GameVersion::kLod1_14B:
+    case ::d2::GameVersion::kLod1_14C:
+    case ::d2::GameVersion::kLod1_14D: {
       return SetDisplayWidthAndHeightPatch_1_09D();
     }
 
-    case d2::GameVersion::k1_13C:
-    case d2::GameVersion::k1_13D: {
+    case ::d2::GameVersion::k1_11:
+    case ::d2::GameVersion::k1_11B:
+    case ::d2::GameVersion::k1_12A:
+    case ::d2::GameVersion::k1_13ABeta:
+    case ::d2::GameVersion::k1_13C:
+    case ::d2::GameVersion::k1_13D: {
       return SetDisplayWidthAndHeightPatch_1_13C();
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_09d.cc
@@ -85,15 +85,6 @@ SetDisplayWidthAndHeightPatch_1_09D::MakePatches() {
       )
   );
 
-  PatchAddressAndSize patch_address_and_size_02 =
-      GetPatchAddressAndSize02();
-  patches.push_back(
-      mapi::GamePatch::MakeGameNopPatch(
-          patch_address_and_size_02.first,
-          patch_address_and_size_02.second
-      )
-  );
-
   return patches;
 }
 
@@ -102,30 +93,88 @@ SetDisplayWidthAndHeightPatch_1_09D::GetPatchAddressAndSize01() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_07Beta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x180F
+          ),
+          0x181D - 0x180F
+      );
+    }
+
+    case ::d2::GameVersion::k1_07:
+    case ::d2::GameVersion::k1_08:
+    case ::d2::GameVersion::k1_09:
+    case ::d2::GameVersion::k1_09B:
     case ::d2::GameVersion::k1_09D: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
               ::d2::DefaultLibrary::kD2DDraw,
               0x181F
           ),
-          0x1832 - 0x181F
+          0x182D - 0x181F
       );
     }
-  }
-}
 
-SetDisplayWidthAndHeightPatch_1_09D::PatchAddressAndSize
-SetDisplayWidthAndHeightPatch_1_09D::GetPatchAddressAndSize02() {
-  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
-
-  switch (running_game_version) {
-    case ::d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_10Beta:
+    case ::d2::GameVersion::k1_10SBeta: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
               ::d2::DefaultLibrary::kD2DDraw,
-              0x1837
+              0x17FA
           ),
-          0x183D - 0x1837
+          0x1808 - 0x17FA
+      );
+    }
+
+    case ::d2::GameVersion::k1_10: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x17EA
+          ),
+          0x17F8 - 0x17EA
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x31E13
+          ),
+          0x31E21 - 0x31E13
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x10F393
+          ),
+          0x10F3A1 - 0x10F393
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x10EF83
+          ),
+          0x10EF91 - 0x10EF83
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x111276
+          ),
+          0x111284 - 0x111276
       );
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_13c.cc
@@ -102,6 +102,46 @@ SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize01() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_11: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x85F6
+          ),
+          0x85FD - 0x85F6
+      );
+    }
+
+    case ::d2::GameVersion::k1_11B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x80A6
+          ),
+          0x80AD - 0x80A6
+      );
+    }
+
+    case ::d2::GameVersion::k1_12A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x8D06
+          ),
+          0x8D0D - 0x8D06
+      );
+    }
+
+    case ::d2::GameVersion::k1_13ABeta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x7606
+          ),
+          0x760D - 0x7606
+      );
+    }
+
     case ::d2::GameVersion::k1_13C: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
@@ -129,6 +169,46 @@ SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize02() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_11: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x8609
+          ),
+          0x8610 - 0x8609
+      );
+    }
+
+    case ::d2::GameVersion::k1_11B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x80B9
+          ),
+          0x80C0 - 0x80B9
+      );
+    }
+
+    case ::d2::GameVersion::k1_12A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x8D19
+          ),
+          0x8D20 - 0x8D19
+      );
+    }
+
+    case ::d2::GameVersion::k1_13ABeta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2DDraw,
+              0x7619
+          ),
+          0x7620 - 0x7619
+      );
+    }
+
     case ::d2::GameVersion::k1_13C: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch.cc
@@ -77,12 +77,27 @@ SetDisplayWidthAndHeightPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_07Beta:
+    case ::d2::GameVersion::k1_07:
+    case ::d2::GameVersion::k1_08:
+    case ::d2::GameVersion::k1_09:
+    case ::d2::GameVersion::k1_09B:
+    case ::d2::GameVersion::k1_09D:
+    case ::d2::GameVersion::k1_10Beta:
+    case ::d2::GameVersion::k1_10SBeta:
+    case ::d2::GameVersion::k1_10: {
       return SetDisplayWidthAndHeightPatch_1_09D();
     }
 
-    case d2::GameVersion::k1_13C:
-    case d2::GameVersion::k1_13D: {
+    case ::d2::GameVersion::k1_11:
+    case ::d2::GameVersion::k1_12A:
+    case ::d2::GameVersion::k1_13ABeta:
+    case ::d2::GameVersion::k1_13C:
+    case ::d2::GameVersion::k1_13D:
+    case ::d2::GameVersion::kLod1_14A:
+    case ::d2::GameVersion::kLod1_14B:
+    case ::d2::GameVersion::kLod1_14C:
+    case ::d2::GameVersion::kLod1_14D: {
       return SetDisplayWidthAndHeightPatch_1_13C();
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_09d.cc
@@ -45,7 +45,16 @@
 
 #include "d2direct3d_set_display_width_and_height_patch_1_09d.hpp"
 
-#include <array>
+#include <stddef.h>
+
+#include <mdc/std/stdint.h>
+
+/*
+* How to find patch locations:
+* 1. Search for the locations where the text
+*    "Failed to create D3D device!" is used.
+* 2. Scroll up until values 640, 480, 800, and 600 are seen.
+*/
 
 extern "C" {
 
@@ -57,12 +66,13 @@ D2Direct3D_SetDisplayWidthAndHeightPatch_1_09D_InterceptionFunc01();
 namespace sgd2fr::patches::d2direct3d {
 namespace {
 
-/**
- * cmp eax, 1
- * jne
- */
-static constexpr std::array<std::uint8_t, 4> kPatchBuffer02 = {
-    0x83, 0xF8, 0x01, 0x75
+static const uint8_t kShortJneByteOpcodes[] = {
+    0x75
+};
+
+enum {
+  kShortJneByteOpcodesCount = sizeof(kShortJneByteOpcodes)
+      / sizeof(kShortJneByteOpcodes[0])
 };
 
 } // namespace
@@ -104,7 +114,7 @@ SetDisplayWidthAndHeightPatch_1_09D::MakePatches() {
   patches.push_back(
       mapi::GamePatch::MakeGameBufferPatch(
           patch_address_and_size_02.first,
-          kPatchBuffer02.data(),
+          kShortJneByteOpcodes,
           patch_address_and_size_02.second
       )
   );
@@ -117,13 +127,39 @@ SetDisplayWidthAndHeightPatch_1_09D::GetPatchAddressAndSize01() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_07Beta:
+    case ::d2::GameVersion::k1_07:
+    case ::d2::GameVersion::k1_08:
+    case ::d2::GameVersion::k1_09:
+    case ::d2::GameVersion::k1_09B:
     case ::d2::GameVersion::k1_09D: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
               ::d2::DefaultLibrary::kD2Direct3D,
               0x2085
           ),
-          0x20C9 - 0x2085
+          0x20C7 - 0x2085
+      );
+    }
+
+    case ::d2::GameVersion::k1_10Beta:
+    case ::d2::GameVersion::k1_10SBeta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x2065
+          ),
+          0x20A7 - 0x2065
+      );
+    }
+
+    case ::d2::GameVersion::k1_10: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x2055
+          ),
+          0x2097 - 0x2055
       );
     }
   }
@@ -134,13 +170,39 @@ SetDisplayWidthAndHeightPatch_1_09D::GetPatchAddressAndSize02() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_07Beta:
+    case ::d2::GameVersion::k1_07:
+    case ::d2::GameVersion::k1_08:
+    case ::d2::GameVersion::k1_09:
+    case ::d2::GameVersion::k1_09B:
     case ::d2::GameVersion::k1_09D: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
               ::d2::DefaultLibrary::kD2Direct3D,
-              0x20C9
+              0x20C7
           ),
-          kPatchBuffer02.size()
+          kShortJneByteOpcodesCount
+      );
+    }
+
+    case ::d2::GameVersion::k1_10Beta:
+    case ::d2::GameVersion::k1_10SBeta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x20A7
+          ),
+          kShortJneByteOpcodesCount
+      );
+    }
+
+    case ::d2::GameVersion::k1_10: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x2097
+          ),
+          kShortJneByteOpcodesCount
       );
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_09d_shim.asm
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_09d_shim.asm
@@ -58,9 +58,13 @@ section .text
 ;
 
 _D2Direct3D_SetDisplayWidthAndHeightPatch_1_09D_InterceptionFunc01:
+    ; Original code
+    mov eax, edi
+
     push ebp
     mov ebp, esp
 
+    push eax
     push ecx
     push edx
 
@@ -70,8 +74,10 @@ _D2Direct3D_SetDisplayWidthAndHeightPatch_1_09D_InterceptionFunc01:
 
     pop edx
     pop ecx
+    pop eax
 
-    mov eax, edi
+    ; Affects jne
+    cmp eax, 1
 
     leave
     ret

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_13c.cc
@@ -45,7 +45,14 @@
 
 #include "d2direct3d_set_display_width_and_height_patch_1_13c.hpp"
 
-#include <array>
+#include <mdc/std/stdint.h>
+
+/*
+* How to find patch locations:
+* 1. Search for the locations where the text
+*    "Failed to create D3D device!" is used.
+* 2. Scroll up until values 640, 480, 800, and 600 are seen.
+*/
 
 extern "C" {
 
@@ -57,12 +64,22 @@ D2Direct3D_SetDisplayWidthAndHeightPatch_1_13C_InterceptionFunc01();
 namespace sgd2fr::patches::d2direct3d {
 namespace {
 
-/**
- * cmp eax, 1
- * je
- */
-constexpr std::array<std::uint8_t, 4> kPatchBuffer02 = {
-    0x83, 0xF8, 0x01, 0x74
+const uint8_t kShortJneByteOpcodes[] = {
+    0x75,
+};
+
+enum {
+  kShortJneByteOpcodesCount = sizeof(kShortJneByteOpcodes)
+      / sizeof(kShortJneByteOpcodes[0])
+};
+
+const uint8_t kShortJmpByteOpcodes[] = {
+    0xEB,
+};
+
+enum {
+  kShortJmpByteOpcodesCount = sizeof(kShortJmpByteOpcodes)
+      / sizeof(kShortJmpByteOpcodes[0])
 };
 
 } // namespace
@@ -98,14 +115,23 @@ SetDisplayWidthAndHeightPatch_1_13C::MakePatches() {
       )
   );
 
-  
   PatchAddressAndSize patch_address_and_size_02 =
       GetPatchAddressAndSize02();
   patches.push_back(
       mapi::GamePatch::MakeGameBufferPatch(
           patch_address_and_size_02.first,
-          kPatchBuffer02.data(),
+          kShortJneByteOpcodes,
           patch_address_and_size_02.second
+      )
+  );
+
+  PatchAddressAndSize patch_address_and_size_03 =
+      GetPatchAddressAndSize03();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBufferPatch(
+          patch_address_and_size_03.first,
+          kShortJmpByteOpcodes,
+          patch_address_and_size_03.second
       )
   );
 
@@ -117,13 +143,44 @@ SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize01() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_11: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x8F14
+          ),
+          0x8F42 - 0x8F14
+      );
+    }
+
+    case ::d2::GameVersion::k1_11B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x9504
+          ),
+          0x9532 - 0x9504
+      );
+    }
+
+    case ::d2::GameVersion::k1_12A:
+    case ::d2::GameVersion::k1_13ABeta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0xFCD4
+          ),
+          0xFD02 - 0xFCD4
+      );
+    }
+
     case ::d2::GameVersion::k1_13C: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
               ::d2::DefaultLibrary::kD2Direct3D,
               0xB9A4
           ),
-          (0xB9DE - kPatchBuffer02.size()) - 0xB9A4
+          0xB9D2 - 0xB9A4
       );
     }
 
@@ -133,7 +190,47 @@ SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize01() {
               ::d2::DefaultLibrary::kD2Direct3D,
               0xBE64
           ),
-          (0xBE9E - kPatchBuffer02.size()) - 0xBE64
+          0xBE92 - 0xBE64
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x11A6F8
+          ),
+          0x11A726 - 0x11A6F8
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x2B62C8
+          ),
+          0x2B62F6 - 0x2B62C8
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x2B5EB8
+          ),
+          0x2B5EE6 - 0x2B5EB8
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x2B500B
+          ),
+          0x2B5039 - 0x2B500B
       );
     }
   }
@@ -144,13 +241,44 @@ SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize02() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_11: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x8F42
+          ),
+          kShortJneByteOpcodesCount
+      );
+    }
+
+    case ::d2::GameVersion::k1_11B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x9532
+          ),
+          kShortJneByteOpcodesCount
+      );
+    }
+
+    case ::d2::GameVersion::k1_12A:
+    case ::d2::GameVersion::k1_13ABeta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0xFD02
+          ),
+          kShortJneByteOpcodesCount
+      );
+    }
+
     case ::d2::GameVersion::k1_13C: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
               ::d2::DefaultLibrary::kD2Direct3D,
-              0xB9DE - kPatchBuffer02.size()
+              0xB9D2
           ),
-          kPatchBuffer02.size()
+          kShortJneByteOpcodesCount
       );
     }
 
@@ -158,9 +286,147 @@ SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize02() {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
               ::d2::DefaultLibrary::kD2Direct3D,
-              0xBE9E - kPatchBuffer02.size()
+              0xBE92
           ),
-          kPatchBuffer02.size()
+          kShortJneByteOpcodesCount
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x11A726
+          ),
+          kShortJneByteOpcodesCount
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x2B62F6
+          ),
+          kShortJneByteOpcodesCount
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x2B5EE6
+          ),
+          kShortJneByteOpcodesCount
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x2B5039
+          ),
+          kShortJneByteOpcodesCount
+      );
+    }
+  }
+}
+
+SetDisplayWidthAndHeightPatch_1_13C::PatchAddressAndSize
+SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize03() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_11: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x8F4D
+          ),
+          kShortJmpByteOpcodesCount
+      );
+    }
+
+    case ::d2::GameVersion::k1_11B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x953D
+          ),
+          kShortJmpByteOpcodesCount
+      );
+    }
+
+    case ::d2::GameVersion::k1_12A:
+    case ::d2::GameVersion::k1_13ABeta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0xFD0D
+          ),
+          kShortJmpByteOpcodesCount
+      );
+    }
+
+    case ::d2::GameVersion::k1_13C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0xB9DD
+          ),
+          kShortJmpByteOpcodesCount
+      );
+    }
+
+    case ::d2::GameVersion::k1_13D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0xBE9D
+          ),
+          kShortJmpByteOpcodesCount
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x11A731
+          ),
+          kShortJmpByteOpcodesCount
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x2B6301
+          ),
+          kShortJmpByteOpcodesCount
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x2B5EF1
+          ),
+          kShortJmpByteOpcodesCount
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Direct3D,
+              0x2B5044
+          ),
+          kShortJmpByteOpcodesCount
       );
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_13c.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_13c.hpp
@@ -73,6 +73,7 @@ class SetDisplayWidthAndHeightPatch_1_13C {
 
   static PatchAddressAndSize GetPatchAddressAndSize01();
   static PatchAddressAndSize GetPatchAddressAndSize02();
+  static PatchAddressAndSize GetPatchAddressAndSize03();
 };
 
 } // namespace sgd2fr::patches::d2direct3d

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_13c_shim.asm
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_13c_shim.asm
@@ -73,5 +73,8 @@ _D2Direct3D_SetDisplayWidthAndHeightPatch_1_13C_InterceptionFunc01:
     pop ecx
     pop eax
 
+    ; Affects jne
+    cmp eax, 1
+
     leave
     ret

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch.cc
@@ -77,13 +77,32 @@ SetBitBlockWidthAndHeightPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_07Beta:
+    case ::d2::GameVersion::k1_07:
+    case ::d2::GameVersion::k1_08:
+    case ::d2::GameVersion::k1_09:
+    case ::d2::GameVersion::k1_09B:
+    case ::d2::GameVersion::k1_09D:
+    case ::d2::GameVersion::k1_10Beta:
+    case ::d2::GameVersion::k1_10SBeta:
+    case ::d2::GameVersion::k1_10: {
       return SetBitBlockWidthAndHeightPatch_1_09D();
     }
 
-    case d2::GameVersion::k1_13C:
-    case d2::GameVersion::k1_13D: {
+    case ::d2::GameVersion::k1_11:
+    case ::d2::GameVersion::k1_11B:
+    case ::d2::GameVersion::k1_12A:
+    case ::d2::GameVersion::k1_13ABeta:
+    case ::d2::GameVersion::k1_13C:
+    case ::d2::GameVersion::k1_13D: {
       return SetBitBlockWidthAndHeightPatch_1_13C();
+    }
+
+    case ::d2::GameVersion::kLod1_14A:
+    case ::d2::GameVersion::kLod1_14B:
+    case ::d2::GameVersion::kLod1_14C:
+    case ::d2::GameVersion::kLod1_14D: {
+      return ::sgd2fr::d2gdi::SetBitBlockWidthAndHeightPatch_Lod1_14A();
     }
   }
 }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch.hpp
@@ -52,6 +52,7 @@
 #include <sgd2mapi.hpp>
 #include "d2gdi_set_bit_block_width_and_height_patch_1_09d.hpp"
 #include "d2gdi_set_bit_block_width_and_height_patch_1_13c.hpp"
+#include "d2gdi_set_bit_block_width_and_height_patch_lod_1_14a.hpp"
 
 namespace sgd2fr::patches::d2gdi {
 
@@ -59,7 +60,8 @@ class SetBitBlockWidthAndHeightPatch {
  public:
   using PatchVariant = std::variant<
       SetBitBlockWidthAndHeightPatch_1_09D,
-      SetBitBlockWidthAndHeightPatch_1_13C
+      SetBitBlockWidthAndHeightPatch_1_13C,
+      ::sgd2fr::d2gdi::SetBitBlockWidthAndHeightPatch_Lod1_14A
   >;
 
   using PatchType = std::optional<PatchVariant>;

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_1_09d.cc
@@ -93,7 +93,24 @@ SetBitBlockWidthAndHeightPatch_1_09D::GetPatchAddressAndSize01() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case ::d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_07Beta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x115A
+          ),
+          0x11BA - 0x115A
+      );
+    }
+
+    case ::d2::GameVersion::k1_07:
+    case ::d2::GameVersion::k1_08:
+    case ::d2::GameVersion::k1_09:
+    case ::d2::GameVersion::k1_09B:
+    case ::d2::GameVersion::k1_09D:
+    case ::d2::GameVersion::k1_10Beta:
+    case ::d2::GameVersion::k1_10SBeta:
+    case ::d2::GameVersion::k1_10: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
               ::d2::DefaultLibrary::kD2GDI,

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_1_13c.cc
@@ -93,23 +93,63 @@ SetBitBlockWidthAndHeightPatch_1_13C::GetPatchAddressAndSize01() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_11: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x6214
+          ),
+          0x623F - 0x6214
+      );
+    }
+
+    case ::d2::GameVersion::k1_11B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x6F24
+          ),
+          0x6F4F - 0x6F24
+      );
+    }
+
+    case ::d2::GameVersion::k1_12A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x6284
+          ),
+          0x62AF - 0x6284
+      );
+    }
+
+    case ::d2::GameVersion::k1_13ABeta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x62E4
+          ),
+          0x630F - 0x62E4
+      );
+    }
+
     case ::d2::GameVersion::k1_13C: {
       return PatchAddressAndSize(
-        ::mapi::GameAddress::FromOffset(
-            ::d2::DefaultLibrary::kD2GDI,
-            0x6D34
-        ),
-        0x6D5F - 0x6D34
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x6D34
+          ),
+          0x6D5F - 0x6D34
       );
     }
 
     case ::d2::GameVersion::k1_13D: {
       return PatchAddressAndSize(
-        ::mapi::GameAddress::FromOffset(
-            ::d2::DefaultLibrary::kD2GDI,
-            0x7B84
-        ),
-        0x7BAF - 0x7B84
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x7B84
+          ),
+          0x7BAF - 0x7B84
       );
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_lod_1_14a.cpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_lod_1_14a.cpp
@@ -43,65 +43,96 @@
  *  work.
  */
 
-#include "d2gdi_set_cel_display_left_and_right_patch.hpp"
+#include "d2gdi_set_bit_block_width_and_height_patch_lod_1_14a.hpp"
 
-namespace sgd2fr::patches::d2gdi {
+#include <stddef.h>
 
-SetCelDisplayLeftAndRightPatch::SetCelDisplayLeftAndRightPatch()
-  : patch_(MakePatch()) {
+extern "C" {
+
+void __cdecl
+D2GDI_SetBitBlockWidthAndHeightPatch_Lod1_14A_InterceptionFunc01();
+
+} // extern "C"
+
+namespace sgd2fr {
+namespace d2gdi {
+
+SetBitBlockWidthAndHeightPatch_Lod1_14A
+::SetBitBlockWidthAndHeightPatch_Lod1_14A()
+    : patches_() {
+  PatchAddressAndSize patch_address_and_size_01 =
+      GetPatchAddressAndSize01();
+  ::mapi::GamePatch patch_01 = mapi::GamePatch::MakeGameBranchPatch(
+      patch_address_and_size_01.first,
+      ::mapi::BranchType::kCall,
+      &D2GDI_SetBitBlockWidthAndHeightPatch_Lod1_14A_InterceptionFunc01,
+      patch_address_and_size_01.second
+  );
+  this->patches_[0].Swap(patch_01);
 }
 
-void SetCelDisplayLeftAndRightPatch::Apply() {
-  if (this->patch_.has_value()) {
-    std::visit([](auto& patch) {
-      patch.Apply();
-    }, this->patch_.value());
+void SetBitBlockWidthAndHeightPatch_Lod1_14A::Apply() {
+  size_t i;
+
+  for (i = 0; i < kPatchesCount; i += 1) {
+    this->patches_[i].Apply();
   }
 }
 
-void SetCelDisplayLeftAndRightPatch::Remove() {
-  if (this->patch_.has_value()) {
-    std::visit([](auto& patch) {
-      patch.Remove();
-    }, this->patch_.value());
+void SetBitBlockWidthAndHeightPatch_Lod1_14A::Remove() {
+  size_t i;
+
+  for (i = kPatchesCount - 1; (i + 1) > 0; i -= 1) {
+    this->patches_[i].Remove();
   }
 }
 
-SetCelDisplayLeftAndRightPatch::PatchType
-SetCelDisplayLeftAndRightPatch::MakePatch() {
-  d2::VideoMode video_mode = d2::DetermineVideoMode();
-  if (video_mode != d2::VideoMode::kGdi) {
-    return std::nullopt;
-  }
-
-  ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
+PatchAddressAndSize
+SetBitBlockWidthAndHeightPatch_Lod1_14A::GetPatchAddressAndSize01() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case ::d2::GameVersion::k1_07Beta:
-    case ::d2::GameVersion::k1_07:
-    case ::d2::GameVersion::k1_08:
-    case ::d2::GameVersion::k1_09:
-    case ::d2::GameVersion::k1_09B:
-    case ::d2::GameVersion::k1_09D:
-    case ::d2::GameVersion::k1_10Beta:
-    case ::d2::GameVersion::k1_10SBeta:
-    case ::d2::GameVersion::k1_10:
-    case ::d2::GameVersion::kLod1_14A:
-    case ::d2::GameVersion::kLod1_14B:
-    case ::d2::GameVersion::kLod1_14C:
-    case ::d2::GameVersion::kLod1_14D: {
-      return SetCelDisplayLeftAndRightPatch_1_09D();
+    case ::d2::GameVersion::kLod1_14A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x106D6F
+          ),
+          0x106D98 - 0x106D6F
+      );
     }
 
-    case ::d2::GameVersion::k1_11:
-    case ::d2::GameVersion::k1_11B:
-    case ::d2::GameVersion::k1_12A:
-    case ::d2::GameVersion::k1_13ABeta:
-    case ::d2::GameVersion::k1_13C:
-    case ::d2::GameVersion::k1_13D: {
-      return SetCelDisplayLeftAndRightPatch_1_13C();
+    case ::d2::GameVersion::kLod1_14B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x2C8F8F
+          ),
+          0x2C8FB8 - 0x2C8F8F
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x2C8B6F
+          ),
+          0x2C8B98 - 0x2C8B6F
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x2C7B32
+          ),
+          0x2C7B5B - 0x2C7B32
+      );
     }
   }
 }
 
-} // namespace sgd2fr::patches::d2gdi
+} // namespace d2gdi
+} // namespace sgd2fr

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_lod_1_14a.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_lod_1_14a.hpp
@@ -43,65 +43,33 @@
  *  work.
  */
 
-#include "d2gdi_set_cel_display_left_and_right_patch.hpp"
+#ifndef SGD2FR_PATCHES_REQUIRED_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_LOD_1_14A_HPP_
+#define SGD2FR_PATCHES_REQUIRED_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_LOD_1_14A_HPP_
 
-namespace sgd2fr::patches::d2gdi {
+#include <sgd2mapi.hpp>
+#include "../../../helper/patch_address_and_size.hpp"
 
-SetCelDisplayLeftAndRightPatch::SetCelDisplayLeftAndRightPatch()
-  : patch_(MakePatch()) {
-}
+namespace sgd2fr {
+namespace d2gdi {
 
-void SetCelDisplayLeftAndRightPatch::Apply() {
-  if (this->patch_.has_value()) {
-    std::visit([](auto& patch) {
-      patch.Apply();
-    }, this->patch_.value());
-  }
-}
+class SetBitBlockWidthAndHeightPatch_Lod1_14A {
+ public:
+  SetBitBlockWidthAndHeightPatch_Lod1_14A();
 
-void SetCelDisplayLeftAndRightPatch::Remove() {
-  if (this->patch_.has_value()) {
-    std::visit([](auto& patch) {
-      patch.Remove();
-    }, this->patch_.value());
-  }
-}
+  void Apply();
+  void Remove();
 
-SetCelDisplayLeftAndRightPatch::PatchType
-SetCelDisplayLeftAndRightPatch::MakePatch() {
-  d2::VideoMode video_mode = d2::DetermineVideoMode();
-  if (video_mode != d2::VideoMode::kGdi) {
-    return std::nullopt;
-  }
+ private:
+  enum {
+    kPatchesCount = 1
+  };
 
-  ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
+  ::mapi::GamePatch patches_[kPatchesCount];
 
-  switch (running_game_version) {
-    case ::d2::GameVersion::k1_07Beta:
-    case ::d2::GameVersion::k1_07:
-    case ::d2::GameVersion::k1_08:
-    case ::d2::GameVersion::k1_09:
-    case ::d2::GameVersion::k1_09B:
-    case ::d2::GameVersion::k1_09D:
-    case ::d2::GameVersion::k1_10Beta:
-    case ::d2::GameVersion::k1_10SBeta:
-    case ::d2::GameVersion::k1_10:
-    case ::d2::GameVersion::kLod1_14A:
-    case ::d2::GameVersion::kLod1_14B:
-    case ::d2::GameVersion::kLod1_14C:
-    case ::d2::GameVersion::kLod1_14D: {
-      return SetCelDisplayLeftAndRightPatch_1_09D();
-    }
+  static PatchAddressAndSize GetPatchAddressAndSize01();
+};
 
-    case ::d2::GameVersion::k1_11:
-    case ::d2::GameVersion::k1_11B:
-    case ::d2::GameVersion::k1_12A:
-    case ::d2::GameVersion::k1_13ABeta:
-    case ::d2::GameVersion::k1_13C:
-    case ::d2::GameVersion::k1_13D: {
-      return SetCelDisplayLeftAndRightPatch_1_13C();
-    }
-  }
-}
+} // namespace d2gdi
+} // namespace sgd2fr
 
-} // namespace sgd2fr::patches::d2gdi
+#endif // SGD2FR_PATCHES_REQUIRED_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_D2GDI_SET_BIT_BLOCK_WIDTH_AND_HEIGHT_PATCH_LOD_1_14A_HPP_

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_lod_1_14a_shim.asm
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_lod_1_14a_shim.asm
@@ -1,0 +1,88 @@
+;
+; SlashGaming Diablo II Free Resolution
+; Copyright (C) 2019-2021  Mir Drualga
+;
+; This file is part of SlashGaming Diablo II Free Resolution.
+;
+;  This program is free software: you can redistribute it and/or modify
+;  it under the terms of the GNU Affero General Public License as published
+;  by the Free Software Foundation, either version 3 of the License, or
+;  (at your option) any later version.
+;
+;  This program is distributed in the hope that it will be useful,
+;  but WITHOUT ANY WARRANTY; without even the implied warranty of
+;  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;  GNU Affero General Public License for more details.
+;
+;  You should have received a copy of the GNU Affero General Public License
+;  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;
+;  Additional permissions under GNU Affero General Public License version 3
+;  section 7
+;
+;  If you modify this Program, or any covered work, by linking or combining
+;  it with Diablo II (or a modified version of that game and its
+;  libraries), containing parts covered by the terms of Blizzard End User
+;  License Agreement, the licensors of this Program grant you additional
+;  permission to convey the resulting work. This additional permission is
+;  also extended to any combination of expansions, mods, and remasters of
+;  the game.
+;
+;  If you modify this Program, or any covered work, by linking or combining
+;  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+;  Glide, OpenGL, or Rave wrapper (or modified versions of those
+;  libraries), containing parts not covered by a compatible license, the
+;  licensors of this Program grant you additional permission to convey the
+;  resulting work.
+;
+;  If you modify this Program, or any covered work, by linking or combining
+;  it with any library (or a modified version of that library) that links
+;  to Diablo II (or a modified version of that game and its libraries),
+;  containing parts not covered by a compatible license, the licensors of
+;  this Program grant you additional permission to convey the resulting
+;  work.
+;
+
+global _D2GDI_SetBitBlockWidthAndHeightPatch_Lod1_14A_InterceptionFunc01
+
+extern _Sgd2fr_D2GDI_GetBitBlockWidthAndHeight
+
+section .data
+
+section .bss
+
+section .text
+
+;
+; External
+;
+
+_D2GDI_SetBitBlockWidthAndHeightPatch_Lod1_14A_InterceptionFunc01:
+    push ebp
+    mov ebp, esp
+
+    sub esp, 8
+
+    push eax
+    push ecx
+    push edx
+
+    lea edi, dword [ebp - 8]
+    push edi
+    lea esi, dword [ebp - 4]
+    push esi
+    push eax
+    call _Sgd2fr_D2GDI_GetBitBlockWidthAndHeight
+    add esp, 12
+
+    pop ecx
+    pop eax
+
+    ; Original code
+    mov edi, dword [ebp - 4]
+    mov esi, dword [ebp - 8]
+
+    add esp, 8
+
+    leave
+    ret

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_09d.cc
@@ -94,6 +94,20 @@ SetCelDisplayLeftAndRightPatch_1_09D::GetPatchAddressAndSize01() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_07Beta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x25B0
+          ),
+          0x25E5 - 0x25B0
+      );
+    }
+
+    case ::d2::GameVersion::k1_07:
+    case ::d2::GameVersion::k1_08:
+    case ::d2::GameVersion::k1_09:
+    case ::d2::GameVersion::k1_09B:
     case ::d2::GameVersion::k1_09D: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
@@ -101,6 +115,58 @@ SetCelDisplayLeftAndRightPatch_1_09D::GetPatchAddressAndSize01() {
               0x25A0
           ),
           0x25D5 - 0x25A0
+      );
+    }
+
+    case ::d2::GameVersion::k1_10Beta:
+    case ::d2::GameVersion::k1_10SBeta:
+    case ::d2::GameVersion::k1_10: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x25C0
+          ),
+          0x25F0 - 0x25C0
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x1074F0
+          ),
+          0x107520 - 0x1074F0
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x2C9710
+          ),
+          0x2C9740 - 0x2C9710
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x2C92F0
+          ),
+          0x2C9320 - 0x2C92F0
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x2C82D0
+          ),
+          0x2C8300 - 0x2C82D0
       );
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_13c.cc
@@ -94,6 +94,46 @@ SetCelDisplayLeftAndRightPatch_1_13C::GetPatchAddressAndSize01() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_11: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x6529
+          ),
+          0x6557 - 0x6529
+      );
+    }
+
+    case ::d2::GameVersion::k1_11B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x7239
+          ),
+          0x7267 - 0x7239
+      );
+    }
+
+    case ::d2::GameVersion::k1_12A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x6599
+          ),
+          0x65C7 - 0x6599
+      );
+    }
+
+    case ::d2::GameVersion::k1_13ABeta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2GDI,
+              0x65F9
+          ),
+          0x6627 - 0x65F9
+      );
+    }
+
     case ::d2::GameVersion::k1_13C: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch.cc
@@ -77,12 +77,25 @@ SetDisplayWidthAndHeightPatch::MakePatch() {
   ::d2::GameVersion running_game_version = d2::game_version::GetRunning();
 
   switch (running_game_version) {
-    case d2::GameVersion::k1_09D: {
+    case ::d2::GameVersion::k1_07Beta:
+    case ::d2::GameVersion::k1_07:
+    case ::d2::GameVersion::k1_08:
+    case ::d2::GameVersion::k1_09D:
+    case ::d2::GameVersion::k1_10Beta:
+    case ::d2::GameVersion::k1_10SBeta:
+    case ::d2::GameVersion::k1_10: {
       return SetDisplayWidthAndHeightPatch_1_09D();
     }
 
-    case d2::GameVersion::k1_13C:
-    case d2::GameVersion::k1_13D: {
+    case ::d2::GameVersion::k1_11:
+    case ::d2::GameVersion::k1_12A:
+    case ::d2::GameVersion::k1_13ABeta:
+    case ::d2::GameVersion::k1_13C:
+    case ::d2::GameVersion::k1_13D:
+    case ::d2::GameVersion::kLod1_14A:
+    case ::d2::GameVersion::kLod1_14B:
+    case ::d2::GameVersion::kLod1_14C:
+    case ::d2::GameVersion::kLod1_14D: {
       return SetDisplayWidthAndHeightPatch_1_13C();
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_09d.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_09d.cc
@@ -45,7 +45,14 @@
 
 #include "d2glide_set_display_width_and_height_patch_1_09d.hpp"
 
-#include <array>
+#include <mdc/std/stdint.h>
+
+/*
+* How to find patch locations:
+* 1. Search for the locations where the text
+*    "Opening Glide window failed!" is used.
+* 2. Scroll up until values 640, 480, 800, and 600 are seen.
+*/
 
 extern "C" {
 
@@ -57,18 +64,16 @@ D2Glide_SetDisplayWidthAndHeightPatch_1_09D_InterceptionFunc01();
 namespace sgd2fr::patches::d2glide {
 namespace {
 
-/**
- * nop
- * nop
- * nop
- * nop
- * nop
- * cmp eax, 1
- * jne D2Glide.dll+1BD1
- */
-static constexpr std::array<std::uint8_t, 10> kPatchBuffer02 = {
-    0x90, 0x90, 0x90, 0x90, 0x90, 0x83, 0xF8, 0x01, 0x75, 0x11
+static const uint8_t kShortJneByteOpcodes[] = { 
+    0x75
 };
+
+enum {
+  kShortJneByteOpcodesSize = sizeof(kShortJneByteOpcodes)
+      / sizeof(kShortJneByteOpcodes[0])
+};
+
+static const uint8_t k0x01Byte = 0x01;
 
 } // namespace
 
@@ -108,8 +113,18 @@ SetDisplayWidthAndHeightPatch_1_09D::MakePatches() {
   patches.push_back(
       mapi::GamePatch::MakeGameBufferPatch(
           patch_address_and_size_02.first,
-          kPatchBuffer02.data(),
+          &k0x01Byte,
           patch_address_and_size_02.second
+      )
+  );
+
+  PatchAddressAndSize patch_address_and_size_03 =
+      GetPatchAddressAndSize03();
+  patches.push_back(
+      mapi::GamePatch::MakeGameBufferPatch(
+          patch_address_and_size_03.first,
+          kShortJneByteOpcodes,
+          patch_address_and_size_03.second
       )
   );
 
@@ -121,6 +136,20 @@ SetDisplayWidthAndHeightPatch_1_09D::GetPatchAddressAndSize01() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_07Beta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x1B3B
+          ),
+          0x1B4F - 0x1B3B
+      );
+    }
+
+    case ::d2::GameVersion::k1_07:
+    case ::d2::GameVersion::k1_08:
+    case ::d2::GameVersion::k1_09:
+    case ::d2::GameVersion::k1_09B:
     case ::d2::GameVersion::k1_09D: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
@@ -128,6 +157,18 @@ SetDisplayWidthAndHeightPatch_1_09D::GetPatchAddressAndSize01() {
               0x1B8B
           ),
           0x1B9F - 0x1B8B
+      );
+    }
+
+    case ::d2::GameVersion::k1_10Beta:
+    case ::d2::GameVersion::k1_10SBeta:
+    case ::d2::GameVersion::k1_10: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x1B96
+          ),
+          0x1BA5 - 0x1B96
       );
     }
   }
@@ -138,13 +179,82 @@ SetDisplayWidthAndHeightPatch_1_09D::GetPatchAddressAndSize02() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_07Beta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x1B66 + 2
+          ),
+          sizeof(k0x01Byte)
+      );
+    }
+
+    case ::d2::GameVersion::k1_07:
+    case ::d2::GameVersion::k1_08:
+    case ::d2::GameVersion::k1_09:
+    case ::d2::GameVersion::k1_09B:
     case ::d2::GameVersion::k1_09D: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
               ::d2::DefaultLibrary::kD2Glide,
-              0x1BB6
+              0x1BB6 + 2
           ),
-          kPatchBuffer02.size()
+          sizeof(k0x01Byte)
+      );
+    }
+
+    case ::d2::GameVersion::k1_10Beta:
+    case ::d2::GameVersion::k1_10SBeta:
+    case ::d2::GameVersion::k1_10: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x1BC1 + 2
+          ),
+          sizeof(k0x01Byte)
+      );
+    }
+  }
+}
+
+SetDisplayWidthAndHeightPatch_1_09D::PatchAddressAndSize
+SetDisplayWidthAndHeightPatch_1_09D::GetPatchAddressAndSize03() {
+  ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
+
+  switch (running_game_version) {
+    case ::d2::GameVersion::k1_07Beta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x1B69
+          ),
+          kShortJneByteOpcodesSize
+      );
+    }
+
+    case ::d2::GameVersion::k1_07:
+    case ::d2::GameVersion::k1_08:
+    case ::d2::GameVersion::k1_09:
+    case ::d2::GameVersion::k1_09B:
+    case ::d2::GameVersion::k1_09D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x1BB9
+          ),
+          kShortJneByteOpcodesSize
+      );
+    }
+
+    case ::d2::GameVersion::k1_10Beta:
+    case ::d2::GameVersion::k1_10SBeta:
+    case ::d2::GameVersion::k1_10: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x1BC4
+          ),
+          kShortJneByteOpcodesSize
       );
     }
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_09d.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_09d.hpp
@@ -73,6 +73,7 @@ class SetDisplayWidthAndHeightPatch_1_09D {
 
   static PatchAddressAndSize GetPatchAddressAndSize01();
   static PatchAddressAndSize GetPatchAddressAndSize02();
+  static PatchAddressAndSize GetPatchAddressAndSize03();
 };
 
 } // namespace sgd2fr::patches::d2glide

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_09d_shim.asm
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_09d_shim.asm
@@ -76,13 +76,13 @@ _D2Glide_SetDisplayWidthAndHeightPatch_1_09D_InterceptionFunc01:
     call _Sgd2fr_D2Glide_SetDisplayWidthAndHeight
     add esp, 16
 
-    ; Load the values to set up the proper state.
-    mov eax, dword [ebx]
-    mov ecx, dword [ebx + 4]
-    mov ebx, dword [ebx + 8]
-
     pop edx
 
+    ; Load the values to set up the proper state.
+    ; width in eax, height in ecx, glide_res_id in ebx
+    mov eax, dword [ebp - 4]
+    mov ecx, dword [ebp - 8]
+    mov ebx, dword [ebp - 12]
     add esp, 12
 
     leave

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_13c.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_13c.cc
@@ -45,7 +45,14 @@
 
 #include "d2glide_set_display_width_and_height_patch_1_13c.hpp"
 
-#include <array>
+#include <mdc/std/stdint.h>
+
+/*
+* How to find patch locations:
+* 1. Search for the locations where the text
+*    "Opening Glide window failed!" is used.
+* 2. Scroll up until values 640, 480, 800, and 600 are seen.
+*/
 
 extern "C" {
 
@@ -57,8 +64,11 @@ D2Glide_SetDisplayWidthAndHeightPatch_1_13C_InterceptionFunc01();
 namespace sgd2fr::patches::d2glide {
 namespace {
 
-constexpr ::std::uint8_t kJeOpcode = 0x74;
-constexpr ::std::uint8_t k01Byte = 0x01;
+static const uint8_t kShortJeByteOpcodes[] = {
+    0x74
+};
+
+static const uint8_t k0x01Byte = 0x01;
 
 } // namespace
 
@@ -98,7 +108,7 @@ SetDisplayWidthAndHeightPatch_1_13C::MakePatches() {
   patches.push_back(
       mapi::GamePatch::MakeGameBufferPatch(
           patch_address_and_size_02.first,
-          &k01Byte,
+          &k0x01Byte,
           patch_address_and_size_02.second
       )
   );
@@ -108,7 +118,7 @@ SetDisplayWidthAndHeightPatch_1_13C::MakePatches() {
   patches.push_back(
       mapi::GamePatch::MakeGameBufferPatch(
           patch_address_and_size_03.first,
-          &kJeOpcode,
+          kShortJeByteOpcodes,
           patch_address_and_size_03.second
       )
   );
@@ -121,6 +131,46 @@ SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize01() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_11: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0xC051
+          ),
+          0xC06A - 0xC051
+      );
+    }
+
+    case ::d2::GameVersion::k1_11B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x8CD1
+          ),
+          0x8CEA - 0x8CD1
+      );
+    }
+
+    case ::d2::GameVersion::k1_12A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0xBD51
+          ),
+          0xBD6A - 0xBD51
+      );
+    }
+
+    case ::d2::GameVersion::k1_13ABeta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x9411
+          ),
+          0x942A - 0x9411
+      );
+    }
+
     case ::d2::GameVersion::k1_13C: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
@@ -140,6 +190,46 @@ SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize01() {
           0xD61A - 0xD601
       );
     }
+
+    case ::d2::GameVersion::kLod1_14A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x35CC0
+          ),
+          0x35CD9 - 0x35CC0
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x1079B0
+          ),
+          0x1079C9 - 0x1079B0
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x1075A0
+          ),
+          0x1075B9 - 0x1075A0
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x109C26
+          ),
+          0x109C3F - 0x109C26
+      );
+    }
   }
 }
 
@@ -148,13 +238,53 @@ SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize02() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_11: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0xC075 + 2
+          ),
+          sizeof(k0x01Byte)
+      );
+    }
+
+    case ::d2::GameVersion::k1_11B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x8CF5 + 2
+          ),
+          sizeof(k0x01Byte)
+      );
+    }
+
+    case ::d2::GameVersion::k1_12A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0xBD75 + 2
+          ),
+          sizeof(k0x01Byte)
+      );
+    }
+
+    case ::d2::GameVersion::k1_13ABeta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x9435 + 2
+          ),
+          sizeof(k0x01Byte)
+      );
+    }
+
     case ::d2::GameVersion::k1_13C: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
               ::d2::DefaultLibrary::kD2Glide,
               0xDD15 + 2
           ),
-          sizeof(k01Byte)
+          sizeof(k0x01Byte)
       );
     }
 
@@ -164,7 +294,47 @@ SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize02() {
               ::d2::DefaultLibrary::kD2Glide,
               0xD625 + 2
           ),
-          sizeof(k01Byte)
+          sizeof(k0x01Byte)
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x35CE4 + 2
+          ),
+          sizeof(k0x01Byte)
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x1079D4 + 2
+          ),
+          sizeof(k0x01Byte)
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x1075C4 + 2
+          ),
+          sizeof(k0x01Byte)
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x109C4A + 2
+          ),
+          sizeof(k0x01Byte)
       );
     }
   }
@@ -175,13 +345,53 @@ SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize03() {
   ::d2::GameVersion running_game_version = ::d2::game_version::GetRunning();
 
   switch (running_game_version) {
+    case ::d2::GameVersion::k1_11: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0xC07E
+          ),
+          sizeof(kShortJeByteOpcodes)
+      );
+    }
+
+    case ::d2::GameVersion::k1_11B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x8CFE
+          ),
+          sizeof(kShortJeByteOpcodes)
+      );
+    }
+
+    case ::d2::GameVersion::k1_12A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0xBD7E
+          ),
+          sizeof(kShortJeByteOpcodes)
+      );
+    }
+
+    case ::d2::GameVersion::k1_13ABeta: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x943E
+          ),
+          sizeof(kShortJeByteOpcodes)
+      );
+    }
+
     case ::d2::GameVersion::k1_13C: {
       return PatchAddressAndSize(
           ::mapi::GameAddress::FromOffset(
               ::d2::DefaultLibrary::kD2Glide,
               0xDD1E
           ),
-          sizeof(kJeOpcode)
+          sizeof(kShortJeByteOpcodes)
       );
     }
 
@@ -191,7 +401,47 @@ SetDisplayWidthAndHeightPatch_1_13C::GetPatchAddressAndSize03() {
               ::d2::DefaultLibrary::kD2Glide,
               0xD62E
           ),
-          sizeof(kJeOpcode)
+          sizeof(kShortJeByteOpcodes)
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14A: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x35CED
+          ),
+          sizeof(kShortJeByteOpcodes)
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14B: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x1079DD
+          ),
+          sizeof(kShortJeByteOpcodes)
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14C: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x1075CD
+          ),
+          sizeof(kShortJeByteOpcodes)
+      );
+    }
+
+    case ::d2::GameVersion::kLod1_14D: {
+      return PatchAddressAndSize(
+          ::mapi::GameAddress::FromOffset(
+              ::d2::DefaultLibrary::kD2Glide,
+              0x109C53
+          ),
+          sizeof(kShortJeByteOpcodes)
       );
     }
   }


### PR DESCRIPTION
This ports all patches associated with a specific video mode to every potentially applicable Diablo II version. The patches are relatively simplistic, and do not require much effort to port. The problem is that running Diablo II in fullscreen is extremely disruptive to the development environment and can shrink all active windows to 640x480. This means having to restore the proper window size for every affected window. Not only that, but the porting environment is also inconvenient to set up, as not all environments can run every video mode without the aid of a virtual machine.

This effectively means that no more work needs to be done to port these patches to 1.07 beta and above, until a new patch for Diablo II is released. 