### PR TITLE
Fix the error message on invalid config read

### DIFF
--- a/SlashGaming-Diablo-II-Free-Resolution/src/config.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/config.cc
@@ -592,8 +592,11 @@ mjsoni::RapidJsonConfigReader ReadConfig(
   bool is_read = config_reader.Read();
   if (!is_read) {
     ::mdc::error::ExitOnGeneralError(
-        L"Failed to read config in %ls.",
         L"Error",
+        L"Failed to read config in %ls. The file may be missing read "
+            L"permissions, or the config is not strictly JSON "
+            L"compliant (such as containing a trailing comma after "
+            L"the last resolution entry).",
         __FILEW__,
         __LINE__,
         config_file_path.c_str()
@@ -605,8 +608,8 @@ mjsoni::RapidJsonConfigReader ReadConfig(
   bool is_missing_entry_added = AddMissingConfigEntries(config_reader);
   if (!is_missing_entry_added) {
     ::mdc::error::ExitOnGeneralError(
-        L"Failed add missing entries to the config in %ls.",
         L"Error",
+        L"Failed add missing entries to the config in %ls.",
         __FILEW__,
         __LINE__,
         config_file_path.c_str()


### PR DESCRIPTION
This doesn't directly fix #23. However, it fixes a problem in the error messages spawned by an invalid config. Instead, the bug is fixed by commit [95f9e6c2d953af9e104a9f43532ef17daaf2f1bb](https://github.com/IAmTrial/Multi-JSON-Interface/commit/95f9e6c2d953af9e104a9f43532ef17daaf2f1bb) in [MJSONI](https://github.com/IAmTrial/Multi-JSON-Interface).