### PR TITLE
Add 856x480 to all existing gateways

### DIFF
--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.cc
@@ -104,6 +104,7 @@ const std::vector<std::tuple<int, int>>& GetResolutionsFromIpV4(
           {
               kResolution640x480,
               kResolution800x600,
+              std::make_tuple(856, 480),
               std::make_tuple(1068, 600)
           }
       ),
@@ -114,6 +115,7 @@ const std::vector<std::tuple<int, int>>& GetResolutionsFromIpV4(
           {
               kResolution640x480,
               kResolution800x600,
+              std::make_tuple(856, 480),
               std::make_tuple(1068, 600)
           }
       ),
@@ -124,6 +126,7 @@ const std::vector<std::tuple<int, int>>& GetResolutionsFromIpV4(
           {
               kResolution640x480,
               kResolution800x600,
+              std::make_tuple(856, 480),
               std::make_tuple(1068, 600)
           }
       ),
@@ -134,6 +137,7 @@ const std::vector<std::tuple<int, int>>& GetResolutionsFromIpV4(
           {
               kResolution640x480,
               kResolution800x600,
+              std::make_tuple(856, 480),
               std::make_tuple(1024, 768),
               std::make_tuple(1068, 600)
           }
@@ -145,6 +149,7 @@ const std::vector<std::tuple<int, int>>& GetResolutionsFromIpV4(
           {
               kResolution640x480,
               kResolution800x600,
+              std::make_tuple(856, 480),
               std::make_tuple(1068, 600)
           }
       ),


### PR DESCRIPTION
The 856x480 resolution appears to be an alternative resolution that has some users, especially since it is a 16:9 resolution with the smaller 480 height.