### PR TITLE
Remove unnecessary uses of std::filesystem

### DIFF
--- a/SlashGaming-Diablo-II-Free-Resolution/src/config.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/config.cc
@@ -736,7 +736,7 @@ void SetIngameResolutionMode(unsigned int resolution_mode) {
   WriteConfig();
 }
 
-::std::string_view GetCustomMpqPath() {
+const ::std::string& GetCustomMpqPath() {
   static std::string custom_mpq_path;
 
   std::call_once(

--- a/SlashGaming-Diablo-II-Free-Resolution/src/config.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/config.hpp
@@ -61,7 +61,7 @@ std::tuple<int, int> GetMainMenuResolution();
 unsigned int GetIngameResolutionMode();
 void SetIngameResolutionMode(unsigned int resolution_mode);
 
-::std::string_view GetCustomMpqPath();
+const ::std::string& GetCustomMpqPath();
 
 std::string_view GetScreenBackgroundImagePath();
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/cel_file_collection.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/cel_file_collection.cc
@@ -69,7 +69,10 @@ static int checksum = 0;
 } // namespace
 
 d2::CelFile_Api& GetCelFile(std::string_view cel_file_path) {
-  const std::string cel_file_path_key = cel_file_path.data();
+  const std::string cel_file_path_key(
+      cel_file_path.cbegin(),
+      cel_file_path.cend()
+  );
 
   if (!cel_file_collection.contains(cel_file_path_key)) {
     if constexpr (kIsLoadCustomMpq) {
@@ -78,7 +81,7 @@ d2::CelFile_Api& GetCelFile(std::string_view cel_file_path) {
 
     cel_file_collection.insert_or_assign(
         cel_file_path_key,
-        ::d2::CelFile_Api(cel_file_path_key, false)
+        ::d2::CelFile_Api(cel_file_path_key.c_str(), false)
     );
   }
 #if defined(FLAG_CHECKSUM)
@@ -95,7 +98,7 @@ d2::CelFile_Api& GetCelFile(std::string_view cel_file_path) {
 
     cel_file_collection.insert_or_assign(
         cel_file_path_key,
-        ::d2::CelFile_Api(cel_file_path_key, false)
+        ::d2::CelFile_Api(cel_file_path_key.c_str(), false)
     );
 #if defined(FLAG_CHECKSUM)
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/custom_mpq.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/custom_mpq.cc
@@ -67,7 +67,7 @@ void LoadMpqOnce() {
   }
 
   GetCustomMpq().Open(
-      config::GetCustomMpqPath(),
+      config::GetCustomMpqPath().c_str(),
       false,
       5000
   );

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/file_version.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/file_version.cc
@@ -48,6 +48,7 @@
 
 #include <algorithm>
 #include <array>
+#include <memory>
 #include <utility>
 
 #include <mdc/error/exit_on_error.hpp>

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/file_version.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/file_version.hpp
@@ -50,7 +50,6 @@
 #include <windows.h>
 
 #include <compare>
-#include <filesystem>
 
 #include "glide3x_version.hpp"
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/glide3x_d2dx.cpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/glide3x_d2dx.cpp
@@ -67,7 +67,8 @@
 
 #include "glide3x_d2dx.hpp"
 
-#include <filesystem>
+#include <windows.h>
+#include <shlwapi.h>
 
 #include <mdc/wchar_t/filew.h>
 #include <mdc/error/exit_on_error.hpp>
@@ -176,7 +177,7 @@ static ID2DXConfigurator* D2DXGetConfigurator() {
 } // namespace
 
 bool IsD2dxGlideWrapper(const wchar_t* path) {
-  if (!::std::filesystem::exists(path)) {
+  if (!::PathFileExistsW(path)) {
     return false;
   }
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open.cc
@@ -52,6 +52,8 @@
 
 namespace sgd2fr::patches {
 
+constexpr const wchar_t* kGlide3xPath = L"glide3x.dll";
+
 void __cdecl Sgd2fr_Glide3x_SetWindowWidthAndHeight(
     std::uint32_t glide_resolution_mode,
     std::int32_t* width,
@@ -65,10 +67,10 @@ void __cdecl Sgd2fr_Glide3x_SetWindowWidthAndHeight(
   switch (running_glide3x_version) {
     case Glide3xVersion::kSven1_4_4_21: {
       width = *reinterpret_cast<std::int32_t**>(
-          ::mapi::GameAddress::FromOffset("glide3x.dll", 0x1C9A0).raw_address()
+          ::mapi::GameAddress::FromOffset(kGlide3xPath, 0x1C9A0).raw_address()
       );
       height = *reinterpret_cast<std::int32_t**>(
-          ::mapi::GameAddress::FromOffset("glide3x.dll", 0x1C82C).raw_address()
+          ::mapi::GameAddress::FromOffset(kGlide3xPath, 0x1C82C).raw_address()
       );
 
       break;
@@ -76,10 +78,10 @@ void __cdecl Sgd2fr_Glide3x_SetWindowWidthAndHeight(
 
     case Glide3xVersion::kSven1_4_6_1: {
       width = *reinterpret_cast<std::int32_t**>(
-          ::mapi::GameAddress::FromOffset("glide3x.dll", 0x1C870).raw_address()
+          ::mapi::GameAddress::FromOffset(kGlide3xPath, 0x1C870).raw_address()
       );
       height = *reinterpret_cast<std::int32_t**>(
-          ::mapi::GameAddress::FromOffset("glide3x.dll", 0x1C830).raw_address()
+          ::mapi::GameAddress::FromOffset(kGlide3xPath, 0x1C830).raw_address()
       );
 
       break;
@@ -87,10 +89,10 @@ void __cdecl Sgd2fr_Glide3x_SetWindowWidthAndHeight(
 
     case Glide3xVersion::kSven1_4_8_3: {
       width = *reinterpret_cast<std::int32_t**>(
-          ::mapi::GameAddress::FromOffset("glide3x.dll", 0x1D870).raw_address()
+          ::mapi::GameAddress::FromOffset(kGlide3xPath, 0x1D870).raw_address()
       );
       height = *reinterpret_cast<std::int32_t**>(
-          ::mapi::GameAddress::FromOffset("glide3x.dll", 0x1D830).raw_address()
+          ::mapi::GameAddress::FromOffset(kGlide3xPath, 0x1D830).raw_address()
       );
 
       break;
@@ -98,10 +100,10 @@ void __cdecl Sgd2fr_Glide3x_SetWindowWidthAndHeight(
 
     case Glide3xVersion::kNGlide3_10_0_658: {
       width = reinterpret_cast<std::int32_t*>(
-          ::mapi::GameAddress::FromOffset("glide3x.dll", 0x169DA4).raw_address()
+          ::mapi::GameAddress::FromOffset(kGlide3xPath, 0x169DA4).raw_address()
       );
       height = reinterpret_cast<std::int32_t*>(
-          ::mapi::GameAddress::FromOffset("glide3x.dll", 0x169F04).raw_address()
+          ::mapi::GameAddress::FromOffset(kGlide3xPath, 0x169F04).raw_address()
       );
 
       break;


### PR DESCRIPTION
The `filesystem` header worsens compile times significantly.