### PR TITLE
Remove string_view abuse

### DIFF
--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/ddraw_version.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/ddraw_version.cc
@@ -51,14 +51,18 @@
 
 namespace sgd2fr::ddraw_version {
 
-::std::string_view GetName(DDrawVersion ddraw_version) {
+const char* GetName(DDrawVersion ddraw_version) {
+  return reinterpret_cast<const char*>(GetNameUtf8(ddraw_version));
+}
+
+const char8_t* GetNameUtf8(DDrawVersion ddraw_version) {
   switch (ddraw_version) {
     case DDrawVersion::kWindowsDefault: {
-      return "Windows Default";
+      return u8"Windows Default";
     }
 
     case DDrawVersion::kCnC: {
-      return "CnC-DDraw";
+      return u8"CnC-DDraw";
     }
 
     default: {
@@ -68,7 +72,7 @@ namespace sgd2fr::ddraw_version {
           static_cast<int>(ddraw_version)
       );
 
-      return "";
+      return u8"";
     }
   }
 }
@@ -80,8 +84,12 @@ DDrawVersion GetRunning() {
   return running_ddraw_version;
 }
 
-::std::string_view GetRunningName() {
-  static ::std::string_view running_ddraw_version_name = GetName(
+const char* GetRunningName() {
+  return reinterpret_cast<const char*>(GetRunningNameUtf8());
+}
+
+const char8_t* GetRunningNameUtf8() {
+  static const char8_t* running_ddraw_version_name = GetNameUtf8(
       GetRunning()
   );
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/ddraw_version.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/ddraw_version.hpp
@@ -46,8 +46,6 @@
 #ifndef SGD2FR_HELPER_DDRAW_VERSION_HPP_
 #define SGD2FR_HELPER_DDRAW_VERSION_HPP_
 
-#include <string_view>
-
 namespace sgd2fr {
 
 enum class DDrawVersion {
@@ -57,13 +55,34 @@ enum class DDrawVersion {
 
 namespace ddraw_version {
 
-::std::string_view GetName(
-    DDrawVersion ddraw_version
-);
+/**
+ * Returns the UTF-8 encoded null-terminated string associated with
+ * the specified DDraw.dll file.
+ */
+const char* GetName(DDrawVersion ddraw_version);
 
+/**
+ * Returns the UTF-8 encoded null-terminated string associated with
+ * the specified DDraw.dll file.
+ */
+const char8_t* GetNameUtf8(DDrawVersion ddraw_version);
+
+/**
+ * Returns the identifier of the running DDraw.dll file.
+ */
 DDrawVersion GetRunning();
 
-::std::string_view GetRunningName();
+/**
+ * Returns the UTF-8 encoded null-terminated string associated with
+ * the running DDraw.dll file.
+ */
+const char* GetRunningName();
+
+/**
+ * Returns the UTF-8 encoded null-terminated string associated with
+ * the running DDraw.dll file.
+ */
+const char8_t* GetRunningNameUtf8();
 
 } // namespace ddraw_version
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/glide3x_version.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/glide3x_version.cc
@@ -53,7 +53,9 @@
 namespace sgd2fr::glide3x_version {
 namespace {
 
-static const wchar_t* const kGlide3xPath = L"glide3x.dll";
+#define GLIDE3X_PATH L"glide3x.dll"
+
+static const wchar_t* const kGlide3xPath = GLIDE3X_PATH;
 
 static Glide3xVersion DetermineGlide3xVersion() {
   if (d2dx_glide::IsD2dxGlideWrapper(kGlide3xPath)) {
@@ -65,22 +67,26 @@ static Glide3xVersion DetermineGlide3xVersion() {
 
 } // namespace
 
-::std::string_view GetName(Glide3xVersion glide3x_version) {
+const char* GetName(Glide3xVersion glide3x_version) {
+  return reinterpret_cast<const char*>(GetNameUtf8(glide3x_version));
+}
+
+const char8_t* GetNameUtf8(Glide3xVersion glide3x_version) {
   switch (glide3x_version) {
     case Glide3xVersion::kSven1_4_4_21: {
-      return "Sven 1.4.4.21";
+      return u8"Sven 1.4.4.21";
     }
 
     case Glide3xVersion::kSven1_4_6_1: {
-      return "Sven 1.4.6.1";
+      return u8"Sven 1.4.6.1";
     }
 
     case Glide3xVersion::kSven1_4_8_3: {
-      return "Sven 1.4.8.3";
+      return u8"Sven 1.4.8.3";
     }
 
     case Glide3xVersion::kNGlide3_10_0_658: {
-      return "nGlide 3.10.0.658";
+      return u8"nGlide 3.10.0.658";
     }
 
     default: {
@@ -90,7 +96,7 @@ static Glide3xVersion DetermineGlide3xVersion() {
           static_cast<int>(glide3x_version)
       );
 
-      return "";
+      return u8"";
     }
   }
 }
@@ -102,8 +108,12 @@ Glide3xVersion GetRunning() {
   return running_glide3x_version;
 }
 
-::std::string_view GetRunningName() {
-  static ::std::string_view running_glide3x_version_name = GetName(
+const char* GetRunningName() {
+  return reinterpret_cast<const char*>(GetRunningNameUtf8());
+}
+
+const char8_t* GetRunningNameUtf8() {
+  static const char8_t* running_glide3x_version_name = GetNameUtf8(
       GetRunning()
   );
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/glide3x_version.hpp
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/glide3x_version.hpp
@@ -46,8 +46,6 @@
 #ifndef SGD2FR_HELPER_GLIDE3X_VERSION_HPP_
 #define SGD2FR_HELPER_GLIDE3X_VERSION_HPP_
 
-#include <string_view>
-
 namespace sgd2fr {
 
 enum class Glide3xVersion {
@@ -60,13 +58,34 @@ enum class Glide3xVersion {
 
 namespace glide3x_version {
 
-::std::string_view GetName(
-    Glide3xVersion glide3x_version
-);
+/**
+ * Returns the UTF-8 encoded null-terminated string associated with
+ * the specified glide3x.dll file.
+ */
+const char* GetName(Glide3xVersion glide3x_version);
 
+/**
+ * Returns the UTF-8 encoded null-terminated string associated with
+ * the specified glide3x.dll file.
+ */
+const char8_t* GetNameUtf8(Glide3xVersion glide3x_version);
+
+/**
+ * Returns the identifier of the running glide3x.dll file.
+ */
 Glide3xVersion GetRunning();
 
-::std::string_view GetRunningName();
+/**
+ * Returns the UTF-8 encoded null-terminated string associated with
+ * the running glide3x.dll file.
+ */
+const char* GetRunningName();
+
+/**
+ * Returns the UTF-8 encoded null-terminated string associated with
+ * the running glide3x.dll file.
+ */
+const char8_t* GetRunningNameUtf8();
 
 } // namespace glide3x_version
 

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open.cc
@@ -52,7 +52,7 @@
 
 namespace sgd2fr::patches {
 
-constexpr const wchar_t* kGlide3xPath = L"glide3x.dll";
+static constexpr const wchar_t* kGlide3xPath = L"glide3x.dll";
 
 void __cdecl Sgd2fr_Glide3x_SetWindowWidthAndHeight(
     std::uint32_t glide_resolution_mode,

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open.cc
@@ -46,13 +46,15 @@
 #include "glide3x_gr_sst_win_open.hpp"
 
 #include <sgd2mapi.hpp>
-
 #include "../../../helper/game_resolution.hpp"
 #include "../../../helper/glide3x_version.hpp"
 
 namespace sgd2fr::patches {
+namespace {
 
 static constexpr const wchar_t* kGlide3xPath = L"glide3x.dll";
+
+} // namespace
 
 void __cdecl Sgd2fr_Glide3x_SetWindowWidthAndHeight(
     std::uint32_t glide_resolution_mode,


### PR DESCRIPTION
Refactors some code that uses `string_view` as a substitute for a null-terminated string. Others that have not been refactored are planned for complete replacement by additions to SGD2MAPI.