### PR TITLE
Add CMakeLists.txt files, update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,46 +1,66 @@
+# Visual C++ 6.0 Data Files
+*.ncb
+*.opt
+*.positions
+*.wwdb
+
+# Binaries
 *.a
 *.dll
 *.exe
+*.lib
 *.o
 *.obj
-*.lib
-*.def
-*.dep
-*.bin
+*.so
 
-*.cfg
-*.json
+# CMake
+out/
+CMakeSettings.json
 
-*.log
-*.tlog
+# Debug / Intermediate Files
+*.ipch
+*.idb
+*.ilk
+*.iobj
+*.ipdb
+*.exp
+*.pch
+*.pdb
+*.recipe
 *.vcxproj.FileListAbsolute.txt
 
-*.cbp
-*.layout
-*.depend
-*.mk
-*.project
-*.workspace
-Makefile
+# Resource Files
+*.aps
+*.res
+
+# Logs
+*.log
+*.plg
+*.tlog
+
+# Thumbnails
+*.DS_STORE
+*.db
+
+# Visual Studio 2005 Solution / Project Files
+*.vcproj
+
+# Visual Studio 2010 Solution / Project Files
+.vs
 
 *.sln
 *.vcxproj
 *.vcxproj.filters
 *.vcxproj.user
 
-*.vcxproj
-*.filters
-*.sdf
-*.sln
-*.suo
+# Visual Studio Code Analysis
+CodeAnalysisResultManifest.txt
+*.lastcodeanalysissucceeded
+*.nativecodeanalysis.all.xml
+*.nativecodeanalysis.sarif
+*.nativecodeanalysis.xml
 
-*/CMakeFiles/*
-CMakeCache.txt
-*.cmake
-
-.build-debug/*
-.codelite/*
-
-.vs/
-Debug/
-Release/
+# Compression Formats
+*.7z
+*.rar
+*.zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,53 @@
+# SlashGaming Diablo II Free Resolution
+# Copyright (C) 2019-2021  Mir Drualga
+#
+# This file is part of SlashGaming Diablo II Free Resolution.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Additional permissions under GNU Affero General Public License version 3
+# section 7
+#
+# If you modify this Program, or any covered work, by linking or combining
+# it with Diablo II (or a modified version of that game and its
+# libraries), containing parts covered by the terms of Blizzard End User
+# License Agreement, the licensors of this Program grant you additional
+# permission to convey the resulting work. This additional permission is
+# also extended to any combination of expansions, mods, and remasters of
+# the game.
+#
+# If you modify this Program, or any covered work, by linking or combining
+# it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+# Glide, OpenGL, or Rave wrapper (or modified versions of those
+# libraries), containing parts not covered by a compatible license, the
+# licensors of this Program grant you additional permission to convey the
+# resulting work.
+#
+# If you modify this Program, or any covered work, by linking or combining
+# it with any library (or a modified version of that library) that links
+# to Diablo II (or a modified version of that game and its libraries),
+# containing parts not covered by a compatible license, the licensors of
+# this Program grant you additional permission to convey the resulting
+# work.
+
+cmake_minimum_required(VERSION 3.14)
+
+project(SGD2FreeResolution)
+
+if (MSVC)
+    add_definitions("-D_CRT_SECURE_NO_WARNINGS")
+endif (MSVC)
+
+add_subdirectory(third_party)
+add_subdirectory(SGD2FreeResolution)

--- a/SGD2FreeResolution/CMakeLists.txt
+++ b/SGD2FreeResolution/CMakeLists.txt
@@ -1,0 +1,597 @@
+# SlashGaming Diablo II Free Resolution
+# Copyright (C) 2019-2021  Mir Drualga
+#
+# This file is part of SlashGaming Diablo II Free Resolution.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Additional permissions under GNU Affero General Public License version 3
+# section 7
+#
+# If you modify this Program, or any covered work, by linking or combining
+# it with Diablo II (or a modified version of that game and its
+# libraries), containing parts covered by the terms of Blizzard End User
+# License Agreement, the licensors of this Program grant you additional
+# permission to convey the resulting work. This additional permission is
+# also extended to any combination of expansions, mods, and remasters of
+# the game.
+#
+# If you modify this Program, or any covered work, by linking or combining
+# it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+# Glide, OpenGL, or Rave wrapper (or modified versions of those
+# libraries), containing parts not covered by a compatible license, the
+# licensors of this Program grant you additional permission to convey the
+# resulting work.
+#
+# If you modify this Program, or any covered work, by linking or combining
+# it with any library (or a modified version of that library) that links
+# to Diablo II (or a modified version of that game and its libraries),
+# containing parts not covered by a compatible license, the licensors of
+# this Program grant you additional permission to convey the resulting
+# work.
+
+cmake_minimum_required(VERSION 3.10)
+
+project(SGD2FreeRes)
+
+set(CMAKE_C_STANDARD 90)
+set(CMAKE_C_STANDARD_REQUIRED true)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED true)
+
+# Header and source files
+set(INCLUDE_HEADERS
+    "include/dllexport_define.inc"
+    "include/dllexport_undefine.inc"
+
+    "include/license.h"
+    "include/sgd2fml_mod_exports.h"
+)
+
+enable_language(ASM_NASM)
+
+set(SRC_ASM
+    # Helpers
+    "src/helper/cel_file_collection_asm.asm"
+
+    # Patches
+
+    ## Draw patches
+    "src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch_1_09d_shim.asm"
+    "src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch_lod_1_14c_shim.asm"
+    "src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch_lod_1_14d_shim.asm"
+
+    "src/patches/draw/d2client_draw_screen_background_patch/d2client_draw_screen_background_patch_1_09d_shim.asm"
+
+    ## Interface bar patches
+    "src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch_1_09d_shim.asm"
+    "src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch_1_13c_shim.asm"
+
+    "src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch_1_09d_shim.asm"
+    "src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch_1_13c_shim.asm"
+
+    "src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_09d_shim.asm"
+    "src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_13c_shim.asm"
+
+    ## Inventory patches
+    "src/patches/inventory/d2common_get_global_belt_record_patch/d2common_get_global_belt_record_patch_1_09d_shim.asm"
+
+    "src/patches/inventory/d2common_get_global_belt_slot_position_patch/d2common_get_global_belt_slot_position_patch_1_09d_shim.asm"
+
+    "src/patches/inventory/d2common_get_global_equipment_slot_layout_patch/d2common_get_global_equipment_slot_layout_patch_1_09d_shim.asm"
+
+    "src/patches/inventory/d2common_get_global_inventory_grid_layout_patch/d2common_get_global_inventory_grid_layout_patch_1_09d_shim.asm"
+
+    "src/patches/inventory/d2common_get_global_inventory_position_patch/d2common_get_global_inventory_position_patch_1_09d_shim.asm"
+
+    ## Required patches
+    "src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_1_09d_shim.asm"
+    "src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_1_13c_shim.asm"
+    "src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_lod_1_14c_shim.asm"
+    "src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_lod_1_14d_shim.asm"
+
+    "src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_1_09d_shim.asm"
+    "src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_1_13c_shim.asm"
+    "src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_lod_1_14c_shim.asm"
+
+    "src/patches/required/d2client_set_general_display_width_and_height_patch/d2client_set_general_display_width_and_height_patch_1_09_shim.asm"
+
+    "src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch_1_09_shim.asm"
+    "src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch_1_13c_shim.asm"
+
+    "src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_1_09d_shim.asm"
+    "src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_1_13c_shim.asm"
+    "src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_lod_1_14c_shim.asm"
+
+    "src/patches/required/d2client_set_screen_shift_patch/d2client_set_screen_shift_patch_1_09d_shim.asm"
+
+    "src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch_1_09d_shim.asm"
+    "src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch_1_13c_shim.asm"
+
+    "src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_09d_shim.asm"
+    "src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_13c_shim.asm"
+
+    "src/patches/required/d2ddraw_set_cel_display_left_and_right_patch/d2ddraw_set_cel_display_left_and_right_patch_1_09d_shim.asm"
+
+    "src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_09d_shim.asm"
+    "src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_13c_shim.asm"
+
+    "src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_09d_shim.asm"
+    "src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_13c_shim.asm"
+
+    "src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_1_09d_shim.asm"
+    "src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_1_13c_shim.asm"
+    "src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_lod_1_14a_shim.asm"
+
+    "src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_09d_shim.asm"
+    "src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_13c_shim.asm"
+
+    "src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window_patch_1_13c_shim.asm"
+
+    "src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window_patch_1_13c_shim.asm"
+
+    "src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch_1_09d_shim.asm"
+    "src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch_1_13c_shim.asm"
+
+    "src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_09d_shim.asm"
+    "src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_13c_shim.asm"
+
+    "src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch_1_13c_shim.asm"
+    "src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch_lod_1_14c_shim.asm"
+    "src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch_lod_1_14d_shim.asm"
+
+    "src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch_nglide_3_10_0_658_shim.asm"
+    "src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch_sven_1_4_4_21_shim.asm"
+    "src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch_sven_1_4_8_3_shim.asm"
+)
+
+set(SRC_C
+    # Helpers
+    "src/helper/800_interface_bar.cc"
+    "src/helper/abstract_multiversion_patch.cpp"
+    "src/helper/abstract_version_patch.cpp"
+    "src/helper/cel_file_collection.cc"
+    "src/helper/custom_mpq.cc"
+    "src/helper/evaluation.c"
+    "src/helper/game_resolution.cc"
+    "src/helper/patch_address_and_size.cpp"
+    "src/helper/position_realignment.cc"
+
+    # Patches
+
+    ## Draw patches
+    "src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background.cc"
+    "src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch.cc"
+    "src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch_1_09d.cc"
+    "src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch_lod_1_14c.cpp"
+    "src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch_lod_1_14d.cpp"
+
+    "src/patches/draw/d2client_draw_screen_background_patch/d2client_draw_screen_background.cc"
+    "src/patches/draw/d2client_draw_screen_background_patch/d2client_draw_screen_background_patch.cc"
+    "src/patches/draw/d2client_draw_screen_background_patch/d2client_draw_screen_background_patch_1_09d.cc"
+
+    "src/patches/draw/draw_patches.cc"
+
+    ## Interface bar patches
+    "src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar.cc"
+    "src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch.cc"
+    "src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch_1_09d.cc"
+    "src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch_1_13c.cc"
+
+    "src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button.cc"
+    "src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch.cc"
+    "src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch_1_09d.cc"
+    "src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch_1_13c.cc"
+
+    "src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button.cc"
+    "src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch.cc"
+    "src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_09d.cc"
+    "src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_13c.cc"
+
+    "src/patches/interface_bar/interface_bar_patches.cc"
+
+    ## Inventory patches
+    "src/patches/inventory/d2common_get_global_belt_record_patch/d2common_get_global_belt_record.cc"
+    "src/patches/inventory/d2common_get_global_belt_record_patch/d2common_get_global_belt_record_patch.cc"
+    "src/patches/inventory/d2common_get_global_belt_record_patch/d2common_get_global_belt_record_patch_1_09d.cc"
+
+    "src/patches/inventory/d2common_get_global_belt_slot_position_patch/d2common_get_global_belt_slot_position.cc"
+    "src/patches/inventory/d2common_get_global_belt_slot_position_patch/d2common_get_global_belt_slot_position_patch.cc"
+    "src/patches/inventory/d2common_get_global_belt_slot_position_patch/d2common_get_global_belt_slot_position_patch_1_09d.cc"
+
+    "src/patches/inventory/d2common_get_global_equipment_slot_layout_patch/d2common_get_global_equipment_slot_layout.cc"
+    "src/patches/inventory/d2common_get_global_equipment_slot_layout_patch/d2common_get_global_equipment_slot_layout_patch.cc"
+    "src/patches/inventory/d2common_get_global_equipment_slot_layout_patch/d2common_get_global_equipment_slot_layout_patch_1_09d.cc"
+
+    "src/patches/inventory/d2common_get_global_inventory_grid_layout_patch/d2common_get_global_inventory_grid_layout.cc"
+    "src/patches/inventory/d2common_get_global_inventory_grid_layout_patch/d2common_get_global_inventory_grid_layout_patch.cc"
+    "src/patches/inventory/d2common_get_global_inventory_grid_layout_patch/d2common_get_global_inventory_grid_layout_patch_1_09d.cc"
+
+    "src/patches/inventory/d2common_get_global_inventory_position_patch/d2common_get_global_inventory_position.cc"
+    "src/patches/inventory/d2common_get_global_inventory_position_patch/d2common_get_global_inventory_position_patch.cc"
+    "src/patches/inventory/d2common_get_global_inventory_position_patch/d2common_get_global_inventory_position_patch_1_09d.cc"
+
+    "src/patches/inventory/inventory_patches.cc"
+
+    ## Required patches
+    "src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch.cc"
+    "src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch_1_09d.cc"
+    "src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch_1_13c.cc"
+
+    "src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text.cc"
+    "src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch.cc"
+    "src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_1_09d.cc"
+    "src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_1_13c.cc"
+    "src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_lod_1_14c.cpp"
+    "src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_lod_1_14d.cpp"
+
+    "src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry.cc"
+    "src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch.cc"
+    "src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_1_09d.cc"
+    "src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_1_13c.cc"
+    "src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_lod_1_14c.cpp"
+
+    "src/patches/required/d2client_set_general_display_width_and_height_patch/d2client_set_general_display_width_and_height.cc"
+    "src/patches/required/d2client_set_general_display_width_and_height_patch/d2client_set_general_display_width_and_height_patch.cc"
+    "src/patches/required/d2client_set_general_display_width_and_height_patch/d2client_set_general_display_width_and_height_patch_1_09.cc"
+
+    "src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu.cc"
+    "src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch.cc"
+    "src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch_1_09.cc"
+    "src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch_1_13c.cc"
+
+    "src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry.cc"
+    "src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch.cc"
+    "src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_1_09d.cc"
+    "src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_1_13c.cc"
+    "src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_lod_1_14c.cpp"
+
+    "src/patches/required/d2client_set_screen_shift_patch/d2client_set_screen_shift.cc"
+    "src/patches/required/d2client_set_screen_shift_patch/d2client_set_screen_shift_patch.cc"
+    "src/patches/required/d2client_set_screen_shift_patch/d2client_set_screen_shift_patch_1_09d.cc"
+
+    "src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection.cc"
+    "src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch.cc"
+    "src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch_1_09d.cc"
+    "src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch_1_13c.cc"
+
+    "src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height.cc"
+    "src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch.cc"
+    "src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_09d.cc"
+    "src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_13c.cc"
+
+    "src/patches/required/d2ddraw_set_cel_display_left_and_right_patch/d2ddraw_set_cel_display_left_and_right.cc"
+    "src/patches/required/d2ddraw_set_cel_display_left_and_right_patch/d2ddraw_set_cel_display_left_and_right_patch.cc"
+    "src/patches/required/d2ddraw_set_cel_display_left_and_right_patch/d2ddraw_set_cel_display_left_and_right_patch_1_09d.cc"
+
+    "src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height.cc"
+    "src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch.cc"
+    "src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_09d.cc"
+    "src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_13c.cc"
+
+    "src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height.cc"
+    "src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch.cc"
+    "src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_09d.cc"
+    "src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_13c.cc"
+
+    "src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height.cc"
+    "src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch.cc"
+    "src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_1_09d.cc"
+    "src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_1_13c.cc"
+    "src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_lod_1_14a.cpp"
+
+    "src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right.cc"
+    "src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch.cc"
+    "src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_09d.cc"
+    "src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_13c.cc"
+
+    "src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window.cc"
+    "src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window_patch.cc"
+    "src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window_patch_1_13c.cc"
+    "src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window_patch_1_13d.cpp"
+
+    "src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window.cc"
+    "src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window_patch.cc"
+    "src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window_patch_1_13c.cc"
+
+    "src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height.cc"
+    "src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch.cc"
+    "src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch_1_09d.cc"
+    "src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch_1_13c.cc"
+
+    "src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height.cc"
+    "src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch.cc"
+    "src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_09d.cc"
+    "src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_13c.cc"
+
+    "src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize.cc"
+    "src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch.cc"
+    "src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch_1_13c.cc"
+    "src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch_lod_1_14c.cpp"
+    "src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch_lod_1_14d.cpp"
+
+    "src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open.cc"
+    "src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch.cc"
+    "src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch_nglide_3_10_0_658.cc"
+    "src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch_sven_1_4_4_21.cc"
+    "src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch_sven_1_4_8_3.cc"
+
+    "src/patches/required/required_patches.cc"
+
+    "src/patches/patches.cc"
+
+    # SGD2MAPI extension
+
+    ## DDraw library version
+    "src/sgd2mapi_extension/ddraw_library_version/ddraw_library_version_product_name.c"
+
+    ## File
+    "src/sgd2mapi_extension/file/file_version_info.c"
+    "src/sgd2mapi_extension/file/fixed_file_version.c"
+
+    ## Game function
+    "src/sgd2mapi_extension/game_function/d2client_function/d2client_draw_screens.cpp"
+
+    ## Glide3x library D2DX
+    "src/sgd2mapi_extension/glide3x_library_d2dx/glide3x_library_d2dx.c"
+    "src/sgd2mapi_extension/glide3x_library_d2dx/glide3x_library_d2dx_cpp98.cpp"
+
+    ## Glide3x library version
+    "src/sgd2mapi_extension/glide3x_library_version/glide3x_library_version_file_version.c"
+
+    "src/sgd2mapi_extension/ddraw_library.c"
+    "src/sgd2mapi_extension/ddraw_library_cpp98.cpp"
+    "src/sgd2mapi_extension/ddraw_library_version.c"
+    "src/sgd2mapi_extension/ddraw_library_version_cpp98.cpp"
+    "src/sgd2mapi_extension/glide3x_library.c"
+    "src/sgd2mapi_extension/glide3x_library_cpp98.cpp"
+    "src/sgd2mapi_extension/glide3x_library_version.c"
+    "src/sgd2mapi_extension/glide3x_library_version_cpp98.cpp"
+
+    "src/config.cc"
+    "src/dll_main.cc"
+    "src/license.c"
+    "src/sgd2fml_mod_exports.cc"
+)
+
+set(SRC_HEADERS
+    # Helpers
+    "src/helper/800_interface_bar.hpp"
+    "src/helper/abstract_multiversion_patch.hpp"
+    "src/helper/abstract_version_patch.hpp"
+    "src/helper/cel_file_collection.hpp"
+    "src/helper/custom_mpq.hpp"
+    "src/helper/evaluation.h"
+    "src/helper/game_resolution.hpp"
+    "src/helper/patch_address_and_size.hpp"
+    "src/helper/position_realignment.hpp"
+
+    # Draw patches
+    "src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background.hpp"
+    "src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch.hpp"
+    "src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch_1_09d.hpp"
+    "src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch_lod_1_14c.hpp"
+    "src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background_patch_lod_1_14d.hpp"
+
+    "src/patches/draw/d2client_draw_screen_background_patch/d2client_draw_screen_background.hpp"
+    "src/patches/draw/d2client_draw_screen_background_patch/d2client_draw_screen_background_patch.hpp"
+    "src/patches/draw/d2client_draw_screen_background_patch/d2client_draw_screen_background_patch_1_09d.hpp"
+
+    "src/patches/draw/draw_patches.hpp"
+
+    # Interface bar patches
+    "src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar.hpp"
+    "src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch.hpp"
+    "src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch_1_09d.hpp"
+    "src/patches/interface_bar/d2client_enable_800_interface_bar_patch/d2client_enable_800_interface_bar_patch_1_13c.hpp"
+
+    "src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button.hpp"
+    "src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch.hpp"
+    "src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch_1_09d.hpp"
+    "src/patches/interface_bar/d2client_enable_800_new_skill_button_patch/d2client_enable_800_new_skill_button_patch_1_13c.hpp"
+
+    "src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button.hpp"
+    "src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch.hpp"
+    "src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_09d.hpp"
+    "src/patches/interface_bar/d2client_enable_800_new_stats_button_patch/d2client_enable_800_new_stats_button_patch_1_13c.hpp"
+
+    "src/patches/interface_bar/interface_bar_patches.hpp"
+
+    # Inventory patches
+    "src/patches/inventory/d2common_get_global_belt_record_patch/d2common_get_global_belt_record.hpp"
+    "src/patches/inventory/d2common_get_global_belt_record_patch/d2common_get_global_belt_record_patch.hpp"
+    "src/patches/inventory/d2common_get_global_belt_record_patch/d2common_get_global_belt_record_patch_1_09d.hpp"
+
+    "src/patches/inventory/d2common_get_global_belt_slot_position_patch/d2common_get_global_belt_slot_position.hpp"
+    "src/patches/inventory/d2common_get_global_belt_slot_position_patch/d2common_get_global_belt_slot_position_patch.hpp"
+    "src/patches/inventory/d2common_get_global_belt_slot_position_patch/d2common_get_global_belt_slot_position_patch_1_09d.hpp"
+
+    "src/patches/inventory/d2common_get_global_equipment_slot_layout_patch/d2common_get_global_equipment_slot_layout.hpp"
+    "src/patches/inventory/d2common_get_global_equipment_slot_layout_patch/d2common_get_global_equipment_slot_layout_patch.hpp"
+    "src/patches/inventory/d2common_get_global_equipment_slot_layout_patch/d2common_get_global_equipment_slot_layout_patch_1_09d.hpp"
+
+    "src/patches/inventory/d2common_get_global_inventory_grid_layout_patch/d2common_get_global_inventory_grid_layout.hpp"
+    "src/patches/inventory/d2common_get_global_inventory_grid_layout_patch/d2common_get_global_inventory_grid_layout_patch.hpp"
+    "src/patches/inventory/d2common_get_global_inventory_grid_layout_patch/d2common_get_global_inventory_grid_layout_patch_1_09d.hpp"
+
+    "src/patches/inventory/d2common_get_global_inventory_position_patch/d2common_get_global_inventory_position.hpp"
+    "src/patches/inventory/d2common_get_global_inventory_position_patch/d2common_get_global_inventory_position_patch.hpp"
+    "src/patches/inventory/d2common_get_global_inventory_position_patch/d2common_get_global_inventory_position_patch_1_09d.hpp"
+
+    "src/patches/inventory/inventory_patches.hpp"
+
+    # Required patches
+    "src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch.hpp"
+    "src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch_1_09d.hpp"
+    "src/patches/required/d2client_disable_mouse_click_on_screen_patch/d2client_disable_mouse_click_on_screen_patch_1_13c.hpp"
+
+    "src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text.hpp"
+    "src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch.hpp"
+    "src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_1_09d.hpp"
+    "src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_1_13c.hpp"
+    "src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_lod_1_14c.hpp"
+    "src/patches/required/d2client_draw_resolution_text_patch/d2client_draw_resolution_text_patch_lod_1_14d.hpp"
+
+    "src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry.hpp"
+    "src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch.hpp"
+    "src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_1_09d.hpp"
+    "src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_1_13c.hpp"
+    "src/patches/required/d2client_get_resolution_registry_patch/d2client_get_resolution_registry_patch_lod_1_14c.hpp"
+
+    "src/patches/required/d2client_set_general_display_width_and_height_patch/d2client_set_general_display_width_and_height.hpp"
+    "src/patches/required/d2client_set_general_display_width_and_height_patch/d2client_set_general_display_width_and_height_patch.hpp"
+    "src/patches/required/d2client_set_general_display_width_and_height_patch/d2client_set_general_display_width_and_height_patch_1_09.hpp"
+
+    "src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu.hpp"
+    "src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch.hpp"
+    "src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch_1_09.hpp"
+    "src/patches/required/d2client_set_resolution_from_options_menu_patch/d2client_set_resolution_from_options_menu_patch_1_13c.hpp"
+
+    "src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry.hpp"
+    "src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch.hpp"
+    "src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_1_09d.hpp"
+    "src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_1_13c.hpp"
+    "src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry_patch_lod_1_14c.hpp"
+
+    "src/patches/required/d2client_set_screen_shift_patch/d2client_set_screen_shift.hpp"
+    "src/patches/required/d2client_set_screen_shift_patch/d2client_set_screen_shift_patch.hpp"
+    "src/patches/required/d2client_set_screen_shift_patch/d2client_set_screen_shift_patch_1_09d.hpp"
+
+    "src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection.hpp"
+    "src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch.hpp"
+    "src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch_1_09d.hpp"
+    "src/patches/required/d2client_unload_cel_file_collection_patch/d2client_unload_cel_file_collection_patch_1_13c.hpp"
+
+    "src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height.hpp"
+    "src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch.hpp"
+    "src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_09d.hpp"
+    "src/patches/required/d2ddraw_set_bit_block_width_and_height_patch/d2ddraw_set_bit_block_width_and_height_patch_1_13c.hpp"
+
+    "src/patches/required/d2ddraw_set_cel_display_left_and_right_patch/d2ddraw_set_cel_display_left_and_right.hpp"
+    "src/patches/required/d2ddraw_set_cel_display_left_and_right_patch/d2ddraw_set_cel_display_left_and_right_patch.hpp"
+    "src/patches/required/d2ddraw_set_cel_display_left_and_right_patch/d2ddraw_set_cel_display_left_and_right_patch_1_09d.hpp"
+
+    "src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height.hpp"
+    "src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch.hpp"
+    "src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_09d.hpp"
+    "src/patches/required/d2ddraw_set_display_width_and_height_patch/d2ddraw_set_display_width_and_height_patch_1_13c.hpp"
+
+    "src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height.hpp"
+    "src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch.hpp"
+    "src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_09d.hpp"
+    "src/patches/required/d2direct3d_set_display_width_and_height_patch/d2direct3d_set_display_width_and_height_patch_1_13c.hpp"
+
+    "src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height.hpp"
+    "src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch.hpp"
+    "src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_1_09d.hpp"
+    "src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_1_13c.hpp"
+    "src/patches/required/d2gdi_set_bit_block_width_and_height_patch/d2gdi_set_bit_block_width_and_height_patch_lod_1_14a.hpp"
+
+    "src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right.hpp"
+    "src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch.hpp"
+    "src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_09d.hpp"
+    "src/patches/required/d2gdi_set_cel_display_left_and_right_patch/d2gdi_set_cel_display_left_and_right_patch_1_13c.hpp"
+
+    "src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window.hpp"
+    "src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window_patch.hpp"
+    "src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window_patch_1_13c.hpp"
+    "src/patches/required/d2gfx_is_need_resize_window_patch/d2gfx_is_need_resize_window_patch_1_13d.hpp"
+
+    "src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window.hpp"
+    "src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window_patch.hpp"
+    "src/patches/required/d2gfx_is_need_restore_down_window_patch/d2gfx_is_need_restore_down_window_patch_1_13c.hpp"
+
+    "src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height.hpp"
+    "src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch.hpp"
+    "src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch_1_09d.hpp"
+    "src/patches/required/d2gfx_set_display_width_and_height_patch/d2gfx_set_display_width_and_height_patch_1_13c.hpp"
+
+    "src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height.hpp"
+    "src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch.hpp"
+    "src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_09d.hpp"
+    "src/patches/required/d2glide_set_display_width_and_height_patch/d2glide_set_display_width_and_height_patch_1_13c.hpp"
+
+    "src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize.hpp"
+    "src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch.hpp"
+    "src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch_1_13c.hpp"
+    "src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch_lod_1_14c.hpp"
+    "src/patches/required/d2win_resize_window_on_maximize_patch/d2win_resize_window_on_maximize_patch_lod_1_14d.hpp"
+
+    "src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open.hpp"
+    "src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch.hpp"
+    "src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch_nglide_3_10_0_658.hpp"
+    "src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch_sven_1_4_4_21.hpp"
+    "src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open_patch_sven_1_4_8_3.hpp"
+
+    "src/patches/required/required_patches.hpp"
+
+    "src/patches/patches.hpp"
+
+    # SGD2MAPI extension
+
+    ## DDraw library version
+    "src/sgd2mapi_extension/ddraw_library_version/ddraw_library_version_product_name.h"
+
+    ## File
+    "src/sgd2mapi_extension/file/file_version_info.h"
+    "src/sgd2mapi_extension/file/fixed_file_version.h"
+
+    ## Game function
+    "src/sgd2mapi_extension/game_function/d2client_function/d2client_draw_screens.hpp"
+
+    "src/sgd2mapi_extension/game_function/d2client_function.hpp"
+
+    ## Glide3x library D2DX
+    "src/sgd2mapi_extension/glide3x_library_d2dx/glide3x_library_d2dx.h"
+
+    ## Glide3x library version
+    "src/sgd2mapi_extension/glide3x_library_version/glide3x_library_version_file_version.h"
+
+    "src/sgd2mapi_extension/ddraw_library.h"
+    "src/sgd2mapi_extension/ddraw_library.hpp"
+    "src/sgd2mapi_extension/ddraw_library_version.h"
+    "src/sgd2mapi_extension/ddraw_library_version.hpp"
+    "src/sgd2mapi_extension/file.h"
+    "src/sgd2mapi_extension/game_function.hpp"
+    "src/sgd2mapi_extension/glide3x_library.h"
+    "src/sgd2mapi_extension/glide3x_library.hpp"
+    "src/sgd2mapi_extension/glide3x_library_version.h"
+    "src/sgd2mapi_extension/glide3x_library_version.hpp"
+    "src/sgd2mapi_extension/sgd2mapi_extension.hpp"
+
+    "src/compile_time_switch.hpp"
+    "src/config.hpp"
+)
+
+# Output DLL
+add_library(SGD2FreeRes SHARED ${SRC_ASM} ${SRC_C} ${SRC_HEADERS} ${INCLUDE_HEADERS})
+
+target_compile_definitions(SGD2FreeRes PRIVATE SGD2FR_DLLEXPORT)
+target_compile_definitions(SGD2FreeRes INTERFACE SGD2FR_DLLIMPORT)
+
+target_include_directories(SGD2FreeRes PUBLIC "include")
+
+target_link_libraries(SGD2FreeRes libSGD2MAPIcxx98 libSGD2MAPIc libMDCcpp98 libMDCc)
+add_dependencies(SGD2FreeRes libSGD2MAPIcxx98 libSGD2MAPIc libMDCcpp98 libMDCc)
+
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}
+    FILES
+        ${SRC_ASM}
+        ${SRC_C}
+        ${SRC_HEADERS}
+        ${INCLUDE_HEADERS}
+)
+
+install(TARGETS SGD2FreeRes)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,0 +1,54 @@
+# SlashGaming Diablo II Free Resolution
+# Copyright (C) 2019-2021  Mir Drualga
+#
+# This file is part of SlashGaming Diablo II Free Resolution.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Additional permissions under GNU Affero General Public License version 3
+# section 7
+#
+# If you modify this Program, or any covered work, by linking or combining
+# it with Diablo II (or a modified version of that game and its
+# libraries), containing parts covered by the terms of Blizzard End User
+# License Agreement, the licensors of this Program grant you additional
+# permission to convey the resulting work. This additional permission is
+# also extended to any combination of expansions, mods, and remasters of
+# the game.
+#
+# If you modify this Program, or any covered work, by linking or combining
+# it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+# Glide, OpenGL, or Rave wrapper (or modified versions of those
+# libraries), containing parts not covered by a compatible license, the
+# licensors of this Program grant you additional permission to convey the
+# resulting work.
+#
+# If you modify this Program, or any covered work, by linking or combining
+# it with any library (or a modified version of that library) that links
+# to Diablo II (or a modified version of that game and its libraries),
+# containing parts not covered by a compatible license, the licensors of
+# this Program grant you additional permission to convey the resulting
+# work.
+
+include(FetchContent)
+
+FetchContent_Declare(MDC
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/MirD-Common-C"
+)
+
+FetchContent_Declare(SGD2MAPI98
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/SlashGaming-Diablo-II-API-1998"
+)
+
+FetchContent_MakeAvailable(MDC SGD2MAPI98)


### PR DESCRIPTION
These changes add `CMakeLists.txt` files and updates to gitignore to filter out CMake junk. This doesn't necessarily mean that the software is able to compile, as work needs to be done to fix incompatibility with SGD2MAPI98.