### PR TITLE
Fix interface bar background off screen

### DIFF
--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/cel_file_collection.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/cel_file_collection.cc
@@ -78,7 +78,7 @@ d2::CelFile_Api& GetCelFile(std::string_view cel_file_path) {
 
     cel_file_collection.insert_or_assign(
         cel_file_path_key,
-        ::d2::CelFile_Api(cel_file_path_key, false)
+        ::d2::CelFile_Api(cel_file_path_key.c_str(), false)
     );
   }
 #if defined(FLAG_CHECKSUM)
@@ -95,7 +95,7 @@ d2::CelFile_Api& GetCelFile(std::string_view cel_file_path) {
 
     cel_file_collection.insert_or_assign(
         cel_file_path_key,
-        ::d2::CelFile_Api(cel_file_path_key, false)
+        ::d2::CelFile_Api(cel_file_path_key.c_str(), false)
     );
 #if defined(FLAG_CHECKSUM)
   }

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/custom_mpq.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/custom_mpq.cc
@@ -67,7 +67,7 @@ void LoadMpqOnce() {
   }
 
   GetCustomMpq().Open(
-      config::GetCustomMpqPath(),
+      config::GetCustomMpqPath().data(),
       false,
       5000
   );

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/draw/d2client_draw_interface_bar_background_patch/d2client_draw_interface_bar_background.cc
@@ -95,7 +95,7 @@ static void DrawLeftInterfaceBarBackground() {
       frame += 1) {
     interface_bar_background_left.DrawFrame(
         width_covered,
-        std::get<1>(width_and_height),
+        std::get<1>(width_and_height) - 1,
         0,
         frame,
         frame_options
@@ -126,7 +126,7 @@ static void DrawLeftInterfaceBarBackground() {
 
     interface_bar_background_center.DrawFrame(
         width_covered,
-        std::get<1>(width_and_height),
+        std::get<1>(width_and_height) - 1,
         0,
         frame_to_draw,
         frame_options
@@ -160,7 +160,7 @@ static void DrawRightInterfaceBarBackground() {
       frame += 1) {
     interface_bar_background_right.DrawFrame(
         std::get<0>(width_and_height) - width_covered,
-        std::get<1>(width_and_height),
+        std::get<1>(width_and_height) - 1,
         0,
         frame,
         frame_options
@@ -189,7 +189,7 @@ static void DrawRightInterfaceBarBackground() {
 
     interface_bar_background_center.DrawFrame(
         std::get<0>(width_and_height) - width_covered,
-        std::get<1>(width_and_height),
+        std::get<1>(width_and_height) - 1,
         0,
         frame_to_draw,
         frame_options

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/glide3x_gr_sst_win_open_patch/glide3x_gr_sst_win_open.cc
@@ -65,10 +65,10 @@ void __cdecl Sgd2fr_Glide3x_SetWindowWidthAndHeight(
   switch (running_glide3x_version) {
     case Glide3xVersion::kSven1_4_4_21: {
       width = *reinterpret_cast<std::int32_t**>(
-          ::mapi::GameAddress::FromOffset("glide3x.dll", 0x1C9A0).raw_address()
+          ::mapi::GameAddress::FromOffset(L"glide3x.dll", 0x1C9A0).raw_address()
       );
       height = *reinterpret_cast<std::int32_t**>(
-          ::mapi::GameAddress::FromOffset("glide3x.dll", 0x1C82C).raw_address()
+          ::mapi::GameAddress::FromOffset(L"glide3x.dll", 0x1C82C).raw_address()
       );
 
       break;
@@ -76,10 +76,10 @@ void __cdecl Sgd2fr_Glide3x_SetWindowWidthAndHeight(
 
     case Glide3xVersion::kSven1_4_6_1: {
       width = *reinterpret_cast<std::int32_t**>(
-          ::mapi::GameAddress::FromOffset("glide3x.dll", 0x1C870).raw_address()
+          ::mapi::GameAddress::FromOffset(L"glide3x.dll", 0x1C870).raw_address()
       );
       height = *reinterpret_cast<std::int32_t**>(
-          ::mapi::GameAddress::FromOffset("glide3x.dll", 0x1C830).raw_address()
+          ::mapi::GameAddress::FromOffset(L"glide3x.dll", 0x1C830).raw_address()
       );
 
       break;
@@ -87,10 +87,10 @@ void __cdecl Sgd2fr_Glide3x_SetWindowWidthAndHeight(
 
     case Glide3xVersion::kSven1_4_8_3: {
       width = *reinterpret_cast<std::int32_t**>(
-          ::mapi::GameAddress::FromOffset("glide3x.dll", 0x1D870).raw_address()
+          ::mapi::GameAddress::FromOffset(L"glide3x.dll", 0x1D870).raw_address()
       );
       height = *reinterpret_cast<std::int32_t**>(
-          ::mapi::GameAddress::FromOffset("glide3x.dll", 0x1D830).raw_address()
+          ::mapi::GameAddress::FromOffset(L"glide3x.dll", 0x1D830).raw_address()
       );
 
       break;
@@ -98,10 +98,10 @@ void __cdecl Sgd2fr_Glide3x_SetWindowWidthAndHeight(
 
     case Glide3xVersion::kNGlide3_10_0_658: {
       width = reinterpret_cast<std::int32_t*>(
-          ::mapi::GameAddress::FromOffset("glide3x.dll", 0x169DA4).raw_address()
+          ::mapi::GameAddress::FromOffset(L"glide3x.dll", 0x169DA4).raw_address()
       );
       height = reinterpret_cast<std::int32_t*>(
-          ::mapi::GameAddress::FromOffset("glide3x.dll", 0x169F04).raw_address()
+          ::mapi::GameAddress::FromOffset(L"glide3x.dll", 0x169F04).raw_address()
       );
 
       break;


### PR DESCRIPTION
These changes fix the interface bar background being cut off by one pixel at the bottom of the screen. The position is adjusted up one pixel to display the full gold border. This fixes #62.

Another solution was considered before deciding on a code-related fix. The vanilla-style solution would be to add an extra pixel height to the Cel themselves. This should appear as a black line that is intended to serve as a buffer when the Cel is drawn at the bottom of the screen. However, this is a workaround and would require coordinating asset updates with mod authors who may not be using standard Cel Files. Given the amount of effort required, it makes more sense to fix this programmatically.