### PR TITLE
Fast forward to 3.0.2.5b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@
   - Remove requirement to install C/C++ runtime files, as they are
     included with every Windows since Windows 95 OSR 2.
 
+## SGD2FreeRes 3.0.2.5b (February 5, 2022)
+- Add Diablo 09's public test realm.
+
+## SGD2FreeRes 3.0.2.5 (January 12, 2022)
+- Fix crash in closed online games due to incorrectly-sized buffer for
+  storing the server's IP's SHA-1 hash.
+
+## SGD2FreeRes 3.0.2.4d (January 10, 2022)
+- Updated timer's server in the supported server list.
+
+## SGD2FreeRes 3.0.2.4c (December 2, 2021)
+- Add timer's server to the supported server list.
+
+## SGD2FreeRes 3.0.2.4b (November 29, 2021)
+- Add 1.09 DiabloFans to the supported server list.
+
+## SGD2FreeRes 3.0.2.4 (November 05, 2021)
+- Fix gateway IPv4 hash verification crash with code NTE_BAD_KEYSET.
+
+## SGD2FreeRes 3.0.2.3b (November 05, 2021)
+- Add Diablo II Evolution to the supported server list.
+
 ## SGD2FreeRes 3.0.2.3 (October 17, 2021)
 - Add ZombiesRUs and D2 Rebirth to the supported server list.
 - Fix D2Resurgence server not being properly detected. The IP address

--- a/SlashGaming-Diablo-II-Free-Resolution/resource/resource.rc
+++ b/SlashGaming-Diablo-II-Free-Resolution/resource/resource.rc
@@ -55,8 +55,8 @@ SLASH_ICON ICON "slashgaming_game_loader.ico"
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 
 VS_VERSION_INFO    VERSIONINFO
-  FILEVERSION      3,0,2,3
-  PRODUCTVERSION   3,0,2,3
+  FILEVERSION      3,0,2,5
+  PRODUCTVERSION   3,0,2,5
   FILEFLAGSMASK    0x3fL // VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
   FILEFLAGS        0x1L  // VS_FF_DEBUG|VS_FF_PRIVATEBUILD|VS_FF_PRERELEASE
@@ -71,17 +71,17 @@ VS_VERSION_INFO    VERSIONINFO
   {
     BLOCK "040904E4" // Lang=US English, CharSet=Windows Multilingual
     {
-      VALUE "Build",            "2021-10-17\0"
+      VALUE "Build",            "2022-02-05\0"
       VALUE "Comments",         "Licensed under Affero GPL v3+.\0"
       VALUE "CompanyName",      "SlashGaming\0"
       VALUE "Developer",        "Mir Drualga\0"
       VALUE "FileDescription",  "Enables customized video resolutions in Diablo II.\0"
       VALUE "InternalName",     "SlashGaming Diablo II Free Resolution\0"
-      VALUE "LegalCopyright",   "Copyright (C) 2019 - 2021  Mir Drualga\0"
+      VALUE "LegalCopyright",   "Copyright (C) 2019 - 2022  Mir Drualga\0"
       VALUE "LegalTrademarks",  "All rights reserved.\0"
       VALUE "PrivateBuild",     "\0"
       VALUE "ProductName",      "Diablo II Free Resolution\0"
-      VALUE "ProductVersion",   "3.0.2.3\0"
+      VALUE "ProductVersion",   "3.0.2.5b\0"
       VALUE "SpecialBuild",     "\0"
       VALUE "Support",          "reddit.com/r/SlashDiablo\0"
     } // BLOCK "040904E4"

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/checksum_hash.c
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/checksum_hash.c
@@ -67,7 +67,7 @@ static void InitCryptProvider(void) {
       NULL,
       NULL,
       PROV_RSA_FULL,
-      0);
+      CRYPT_VERIFYCONTEXT);
 
   if (!is_crypt_acquire_context_success) {
     Mdc_Error_ExitOnWindowsFunctionError(

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.cc
@@ -96,8 +96,30 @@ const std::vector<std::tuple<int, int>>& GetResolutionsFromIpV4(
   // Warning: This needs to be sorted lexicographically!
   static const ::std::array<
       Ipv4HashResolutionTableEntry,
-      8
+      13
   > kSortedIpv4ResolutionTable = {{
+
+      // timer's server (old)
+      Ipv4HashResolutionTableEntry(
+          "1EF04EB4585C6521BDD6F644D0AB3D2020EC4600",
+          {
+              kResolution800x600,
+              std::make_tuple(1024, 768),
+              std::make_tuple(1280, 720),
+              std::make_tuple(1440, 900),
+              std::make_tuple(1920, 1080),
+          }
+      ),
+
+      // ptr.diablo09.com
+      Ipv4HashResolutionTableEntry(
+          "22A3E5D23BD68EED6A8163EB1F17F0A74EA3D119",
+          {
+              kResolution640x480,
+              kResolution800x600,
+              std::make_tuple(856, 480),
+              std::make_tuple(1068, 600)
+          }),
 
       // Rebirth D2
       Ipv4HashResolutionTableEntry(
@@ -109,6 +131,28 @@ const std::vector<std::tuple<int, int>>& GetResolutionsFromIpV4(
               std::make_tuple(1024, 768),
               std::make_tuple(1068, 600),
               std::make_tuple(1280, 768)
+          }
+      ),
+
+      // timer's server
+      Ipv4HashResolutionTableEntry(
+          "44EBC5EE6B0C2D5474233AD3370161FA5CFE560D",
+          {
+              kResolution800x600,
+              std::make_tuple(1024, 768),
+              std::make_tuple(1280, 720),
+              std::make_tuple(1440, 900),
+              std::make_tuple(1920, 1080),
+          }
+      ),
+
+      // Diablo II Evolution
+      Ipv4HashResolutionTableEntry(
+          "4A0C205D82F5A1089606505350B5096829E9182C",
+          {
+                kResolution800x600,
+                std::make_tuple(1068, 600),
+                std::make_tuple(1280, 720),
           }
       ),
 
@@ -187,6 +231,16 @@ const std::vector<std::tuple<int, int>>& GetResolutionsFromIpV4(
               kResolution800x600,
               std::make_tuple(856, 480),
               std::make_tuple(1068, 600)
+          }
+      ),
+
+      // 1.09 DiabloFans
+      Ipv4HashResolutionTableEntry(
+          "FCCB6017F496BD14AB7281E963E969D94C176568",
+          {
+              kResolution800x600,
+              std::make_tuple(1024, 768),
+              std::make_tuple(1244, 700),
           }
       ),
   }};

--- a/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/helper/game_resolution.cc
@@ -196,7 +196,7 @@ const std::vector<std::tuple<int, int>>& GetResolutionsFromIpV4(
       kResolution800x600
   };
 
-  char sha1_str[Sha1_kLength];
+  char sha1_str[Sha1_kLength + 1];
   Sha1_GenerateHash(sha1_str, ipv4_address.data(), ipv4_address.length());
 
   ::std::pair search_range = ::std::equal_range(


### PR DESCRIPTION
These changes include various bug fixes related to crashes during the SHA-1 hash generation.  New gateway IPv4 SHA-1 hashes have also been added.