### PR TITLE
Disable thread library calls

### DIFF
--- a/SlashGaming-Diablo-II-Free-Resolution/src/dll_main.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/dll_main.cc
@@ -56,6 +56,14 @@ BOOL WINAPI DllMain(
     DWORD fdwReason,
     LPVOID lpvReserved
 ) {
+  BOOL is_disable_thread_library_calls_success;
+
+  is_disable_thread_library_calls_success =
+      DisableThreadLibraryCalls(hinstDLL);
+  if (!is_disable_thread_library_calls_success) {
+    return FALSE;
+  }
+
   switch (fdwReason) {
     case DLL_PROCESS_ATTACH: {
       Sgd2fml_Mod_OnLoadMpqs();


### PR DESCRIPTION
These changes [disable threaded library calls](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-disablethreadlibrarycalls#remarks) in DllMain, for optimization purposes.