### PR TITLE
Fix crash when 640x480 is the only resolution

### DIFF
--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_resolution_registry_patch/d2client_set_resolution_registry.cc
@@ -48,6 +48,7 @@
 #include <sgd2mapi.hpp>
 
 #include "../../../config.hpp"
+#include "../../../helper/game_resolution.hpp"
 
 namespace sgd2fr::patches {
 
@@ -61,7 +62,8 @@ void __cdecl Sgd2fr_D2Client_SetResolutionRegistry(
       reg_resolution_mode
   );
 
-  if (reg_resolution_mode == 0) {
+  if (reg_resolution_mode == 0
+      || reg_resolution_mode >= GetMaxConfigResolutionId()) {
     *ingame_resolution_mode = 0;
   } else {
     *ingame_resolution_mode = reg_resolution_mode + 1;


### PR DESCRIPTION
These changes fix a crash caused by switching resolutions when 640x480 is the only resolution available.