### PR TITLE
Extend tile culling bound more

### DIFF
--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_tile_culling_bound_patch/d2client_set_tile_culling_bound.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_tile_culling_bound_patch/d2client_set_tile_culling_bound.cc
@@ -81,10 +81,10 @@ void __cdecl Sgd2fr_D2Client_SetTileCullingBound(
   RECT* tile_culling_rect = &culling_spec->tile_culling_window;
   SetRect(
       tile_culling_rect,
-      -80,
-      -80,
-      GetGeneralDisplayWidth() + 80,
-      GetGeneralDisplayHeight() + 80);
+      -160,
+      -160,
+      GetGeneralDisplayWidth() + 160,
+      GetGeneralDisplayHeight() + 160);
   if (GetIsPerspectiveModeEnabled()) {
     tile_culling_rect->top -= 160;
     tile_culling_rect->left -= 320;

--- a/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_tile_culling_bound_patch/d2client_set_tile_culling_bound_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/patches/required/d2client_set_tile_culling_bound_patch/d2client_set_tile_culling_bound_patch.cc
@@ -90,9 +90,13 @@ AbstractVersionPatch* SetTileCullingBoundPatch::InitPatch() {
     case GameVersion::k1_10Beta:
     case GameVersion::k1_10SBeta:
     case GameVersion::k1_10:
+    case GameVersion::kClassic1_14A:
     case GameVersion::kLod1_14A:
+    case GameVersion::kClassic1_14B:
     case GameVersion::kLod1_14B:
+    case GameVersion::kClassic1_14C:
     case GameVersion::kLod1_14C:
+    case GameVersion::kClassic1_14D:
     case GameVersion::kLod1_14D: {
       return new SetTileCullingBoundPatch_1_07();
     }


### PR DESCRIPTION
These changes extend the extend tile culling bound by a bit more to fix tile culling issues in D2DX with motion prediction. This does not fully solve all of its problems. Necrolis indicates that some tile culling issues can be due to the motion prediction of D2DX.