### PR TITLE
Hide DisableThreadLibraryCalls in DllMain

### DIFF
--- a/SlashGaming-Diablo-II-Free-Resolution/src/dll_main.cc
+++ b/SlashGaming-Diablo-II-Free-Resolution/src/dll_main.cc
@@ -56,16 +56,18 @@ BOOL WINAPI DllMain(
     DWORD fdwReason,
     LPVOID lpvReserved
 ) {
-  BOOL is_disable_thread_library_calls_success;
-
-  is_disable_thread_library_calls_success =
-      DisableThreadLibraryCalls(hinstDLL);
-  if (!is_disable_thread_library_calls_success) {
-    return FALSE;
-  }
-
   switch (fdwReason) {
     case DLL_PROCESS_ATTACH: {
+#if 0  /* Windows 7 fails to load the DLL with this code enabled. */
+      BOOL is_disable_thread_library_calls_success;
+
+      is_disable_thread_library_calls_success =
+          DisableThreadLibraryCalls(hinstDLL);
+      if (!is_disable_thread_library_calls_success) {
+        return FALSE;
+      }
+#endif
+
       Sgd2fml_Mod_OnLoadMpqs();
 
       return TRUE;


### PR DESCRIPTION
These changes fix Windows 7 not being able to load the DLL.